### PR TITLE
Add filters of varying sizes and dropout to CNN

### DIFF
--- a/kaggle-classification/run.sh
+++ b/kaggle-classification/run.sh
@@ -14,12 +14,10 @@ BUCKET_NAME=kaggle-model-experiments
 JOB_NAME=test_kaggle_training
 REGION=us-central1
 
-
 DATE=`date '+%Y%m%d_%H%M%S'`
 OUTPUT_PATH=gs://${BUCKET_NAME}/${DATE}
 
 echo "Writing to $OUTPUT_PATH"
-exit
 
 # Remote
 gcloud ml-engine jobs submit training ${JOB_NAME}_${DATE} \
@@ -33,7 +31,7 @@ gcloud ml-engine jobs submit training ${JOB_NAME}_${DATE} \
     --train_data gs://${BUCKET_NAME}/train.csv \
     --y_class toxic \
     ---predict_data gs://${BUCKET_NAME}/test.csv \
-    --train_steps 1000 \
-    --saved_model_dir gs://${BUCKET_NAME}/saved_models\
-    --model_dir gs://${BUCKET_NAME}/model \
+    --train_steps 1500 \
+    --saved_model_dir gs://${BUCKET_NAME}/saved_models \
+    --model_dir gs://${BUCKET_NAME}/model/${DATE} \
     --model cnn \

--- a/kaggle-classification/trainer/model.py
+++ b/kaggle-classification/trainer/model.py
@@ -46,7 +46,7 @@ MAX_DOCUMENT_LENGTH = 500 # Max length of each comment in words
 CNNParams = namedtuple(
   'CNNParams',['EMBEDDING_SIZE','N_FILTERS', 'FILTER_SIZES', 'DROPOUT_KEEP_PROB'])
 CNN_PARAMS = CNNParams(
-  EMBEDDING_SIZE=20, N_FILTERS=10, FILTER_SIZES=[2,3,4,5],  DROPOUT_KEEP_PROB=.75)
+  EMBEDDING_SIZE=50, N_FILTERS=10, FILTER_SIZES=[2,3,4,5],  DROPOUT_KEEP_PROB=.75)
 
 # Bag of Word parameters
 BOWParams = namedtuple('BOWParams', ['EMBEDDING_SIZE'])


### PR DESCRIPTION
This change is a rewrite of the CNN model which adds
* filters of multiple sizes
* dropout during training

 I had previously adapted the implementation from one of the examples in the TensorFlow Github repo ([here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/text_classification_cnn.py)), but JJ pointed out that it only used one filter size. I also found the `tf.layers` API a little confusing. 

JJ pointed me to [this](http://www.wildml.com/2015/12/implementing-a-cnn-for-text-classification-in-tensorflow/) Wild ML CNN tutorial that uses filters of multiple sizes and adds dropout during training. It also uses lower level TensorFlow API's and is a bit easier to read. 

I ran both models on the Kaggle data to predict toxicity and the AUC went up from .76 to .80. Without any tuning, just run for the same number of time steps.

The update to `run.sh` makes it possible to run multiple models remotely at the same time. Previously we were saving all the checkpoints to the same Cloud Storage directory. 

This closes https://github.com/conversationai/conversationai-models/issues/8 