### PR TITLE
support python 3, readme tweaks, and run_local fixes

### DIFF
--- a/kaggle-classification/.gitignore
+++ b/kaggle-classification/.gitignore
@@ -1,6 +1,3 @@
-# Don't version control data
-*.csv
-
 # Directories to save model checkpoints
 model/*
 saved_models/*
@@ -9,3 +6,12 @@ saved_models/*
 __pycache__/
 *.py[cod]
 *$py.class
+
+# Python virtual environment directory
+env/
+
+# Don't version control data: this is the directory where data is downloaded to.
+local_data/
+
+# Temporary directory for hacking stuff in
+tmp/

--- a/kaggle-classification/README.md
+++ b/kaggle-classification/README.md
@@ -1,31 +1,79 @@
 # Toxic Comment Classification Kaggle Challenge
 
-This directory is a place to play around with solutions for the [Toxic Comment Classification Kaggle challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge). The challenge was created by the Jigsaw Conversation AI team in December 2017
+This directory is a place to play around with solutions for the
+[Toxic Comment Classification Kaggle challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge).
+The challenge was created by the Jigsaw Conversation AI team in December 2017
 and the it ends in February 2018.
 
-These models are meant to be simple baselines created independently from the Google infrastructure.
+These models are meant to be simple baselines created independently from the
+Google infrastructure.
+
 
 ## To Run Locally
-1. Download the training (`train.csv`) and test (`test.csv`) data from the
-[Kaggle challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/data).
 
-2. Setup a (virtualenv)[https://virtualenvwrapper.readthedocs.io/en/latest/] for the project(Optional)
+1.  Setup a (virtualenv)[https://virtualenvwrapper.readthedocs.io/en/latest/] for
+    the project (recommended, but technically optional).
 
-3. Install library dependencies:
-```shell
-pip install -r requirements.txt
-```
+    Python 2:
 
-4. Run a model on a given class (e.g. 'toxic' or 'obscene'). There are examples of how to
-run the model locally and using ml-engine in `run_local.sh` and `run.sh` respectively.
+    ```
+    python -m virtualenv env
+    ```
+
+    Python 3:
+
+    ```
+    python3 -m venv env
+    ```
+
+    From either to enter your virtual env:
+
+    ```shell
+    source env/bin/activate
+    ```
+
+2.  Install library dependencies:
+
+    ```shell
+    pip install -r requirements.txt
+    ```
+
+3.  For training locally, download the training (`train.csv`) and test
+    (`test.csv`) data from the
+    [Kaggle challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/data).
+
+    If you have [a Kaggle API Key](https://github.com/Kaggle/kaggle-api#api-credentials)
+    setup, you can use the [Kaggle api tool](https://github.com/Kaggle/kaggle-api)
+    to download these files by running:
+
+    ```shell
+    kaggle competitions download -c jigsaw-toxic-comment-classification-challenge -p ./
+    mv jigsaw-toxic-comment-classification-challenge local_data
+    for z in local_data/*.zip; do unzip -x $z -d local_data/; done
+    ```
+
+    Note: the `kaggle` command is installed from the `pip` and specified in
+    `requirements.txt`.
+
+4.  Run a model on a given class (e.g. 'toxic' or 'obscene'). There are examples
+    of how to run the model locally and using ml-engine in `run_local.sh` and
+    `run.sh` respectively.
+
+    Note: to run in google cloud, you will need to be authenticated with
+    Google Cloud (you can run `gcloud auth application-default login` to do
+    this) and you must have access to the cloud bucket where the data is located
+    (you can test this by running `gsutil ls  gs://kaggle-model-experiments/`).
 
 
 ## Available Models
   * `bag_of_words` - bag of words model with a learned word-embedding layer
   * `cnn` - a 2 layer ConvNet
 
+
 ## Data
-Copies of the training and test data are available in Google Storage from the wikidetox project.
+
+Copies of the training and test data are available in Google Storage from the
+wikidetox project.
 
 * train.csv: gs://kaggle-model-experiments/train.csv
 * test.csv: gs://kaggle-model-experiments/test.csv

--- a/kaggle-classification/requirements.txt
+++ b/kaggle-classification/requirements.txt
@@ -3,6 +3,7 @@ bleach==1.5.0
 enum34==1.1.6
 futures==3.1.1
 html5lib==0.9999999
+kaggle==1.0.5
 Markdown==2.6.11
 numpy==1.14.0
 pandas==0.22.0
@@ -13,6 +14,6 @@ scikit-learn==0.19.1
 scipy==1.0.0
 six==1.11.0
 sklearn==0.0
-tensorflow==1.3.0
 tensorflow-tensorboard==1.5.0
+tensorflow==1.3.0
 Werkzeug==0.14.1

--- a/kaggle-classification/run_local.sh
+++ b/kaggle-classification/run_local.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
 #
-# A script to train the kaggle model locally
+# A script to train the kaggle model locally.
+# Assumes that train.csv and test.csv are downloaded into the local_data/
+# directory.
 #
 
 gcloud ml-engine local train \
      --module-name=trainer.model \
      --package-path=trainer \
      --job-dir=model -- \
-     --train_data=gs://kaggle-model-experiments/train.csv \
-     --predict_data=gs://kaggle-model-experiments/test.csv \
+     --train_data=local_data/train.csv \
+     --predict_data=local_data/test.csv \
      --y_class=toxic \
      --train_steps=100

--- a/kaggle-classification/trainer/wikidata.py
+++ b/kaggle-classification/trainer/wikidata.py
@@ -2,7 +2,6 @@
 Class to encapsulate training and test data.
 """
 
-import codecs
 import numpy as np
 import pandas as pd
 import tensorflow as tf

--- a/kaggle-classification/trainer/wikidata.py
+++ b/kaggle-classification/trainer/wikidata.py
@@ -2,6 +2,7 @@
 Class to encapsulate training and test data.
 """
 
+import codecs
 import numpy as np
 import pandas as pd
 import tensorflow as tf
@@ -73,8 +74,8 @@ class WikiData:
     Will work with a Cloud Storage path, e.g. 'gs://<bucket>/<blob>' or a local
     path. Assumes data can fit into memory.
     """
-    with tf.gfile.Open(path, 'r') as fileobj:
-      df =  pd.read_csv(fileobj)
+    with tf.gfile.Open(path, 'rb') as fileobj:
+      df =  pd.read_csv(fileobj, encoding='utf-8')
 
     return df
 


### PR DESCRIPTION
* Moved local data to a `local_data` directory. 
* Added command line instructions for downloading local data. 
* Made `run_local.sh` use data in `local_data` directory (so it's really totally local)
* Fixed loading code to work in python3 (utf-8 fixes)
* Adds more detailed instructions, and recommends using virtualenv
* Sort the `requirements.txt` because sorting is cool. 