### PR TITLE
Add evaluation script

### DIFF
--- a/kaggle-classification/trainer/eval.py
+++ b/kaggle-classification/trainer/eval.py
@@ -27,12 +27,12 @@ MAX_DOCUMENT_LENGTH = 500
 def predict(data, classifier):
     """
     Args:
-      data: n x m array of features where n is the number of examples
+      data: (n, m) array of features where n is the number of examples
             and m is the number of features.
       classifier: a SavedModelPredictor with an input tensor 'input' that
                   expects as input a list of tf.train.Example's.
     Returns:
-      scores: a n x num_classes array of scores for each each class
+      scores: (n, num_classes) array of scores for each each class
     """
     model_inputs = []
 

--- a/kaggle-classification/trainer/eval.py
+++ b/kaggle-classification/trainer/eval.py
@@ -1,0 +1,93 @@
+"""
+Evaluates a model on data. Takes a path to a directory with a TensorFlow
+SavedModel and a path to a CSV with data, and outputs the predictions of the
+model on the data.
+
+Example usage:
+
+python trainer/eval.py  \
+  --model_dir=saved_models/{timestamp}/ \
+  --test_data=local_data/test.csv
+"""
+
+import argparse
+import numpy as np
+import pandas as pd
+import wikidata
+import tensorflow as tf
+
+# Name of the input words feature
+WORDS_FEATURE = 'words'
+
+# TODO: infer this from the saved model
+MAX_DOCUMENT_LENGTH = 500
+
+def predict(data, classifier):
+    """
+    Args:
+      data: n x m array of features where n is the number of examples
+            and m is the number of features.
+      classifier: a SavedModelPredictor with an input tensor 'input' that
+                  expects as input a list of tf.train.Example's.
+    Returns:
+      scores: a n x num_classes array of scores for each each class
+    """
+    model_inputs = []
+
+    for d in data:
+        input = tf.train.Example(
+            features=tf.train.Features(
+                feature={
+                    WORDS_FEATURE: tf.train.Feature(
+                        int64_list=tf.train.Int64List(value=d)
+                    )
+                }
+            )
+        )
+
+        model_inputs.append(input.SerializeToString())
+
+    output_dict = classifier({'inputs': model_inputs})
+    scores = output_dict['scores']
+
+    return scores
+
+def load_model(session, model_dir):
+    """Loads SavedModel model and returns classifier."""
+    tf.saved_model.loader.load(
+        session, [tf.saved_model.tag_constants.SERVING], model_dir)
+
+    classifier = tf.contrib.predictor.from_saved_model(model_dir)
+
+    return classifier
+
+def main():
+
+    with tf.Session(graph=tf.Graph()) as sess:
+        classifier = load_model(sess, FLAGS.model_dir)
+
+    # load test data
+    data = wikidata.WikiData(
+        data_path=FLAGS.test_data,
+        max_document_length=MAX_DOCUMENT_LENGTH,
+        model_dir=FLAGS.model_dir,
+        predict_mode=True)
+
+    # evaluate model on data
+    # TODO: For now, this just prints out the 10 first examples.
+    #       This isn't very useful.
+    test_data = data.x_test[0:10]
+    scores = predict(test_data, classifier)
+
+    for i in range(len(scores)):
+        print scores[i][0], data.x_test_text[i]
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--test_data', help='Path to data to evaluate on.', type=str)
+    parser.add_argument('--model_dir', help='Path to directory with TF model.', type=str)
+
+    FLAGS, unparsed = parser.parse_known_args()
+
+    main()

--- a/kaggle-classification/trainer/eval.py
+++ b/kaggle-classification/trainer/eval.py
@@ -8,8 +8,10 @@ Example usage:
 python trainer/eval.py  \
   --model_dir=saved_models/{timestamp}/ \
   --test_data=local_data/test.csv
+  --n_examples=1000
 """
 import sys
+import json
 import argparse
 import numpy as np
 import pandas as pd
@@ -24,19 +26,19 @@ WORDS_FEATURE = 'words'
 # TODO: infer this from the saved model
 MAX_DOCUMENT_LENGTH = 500
 
-def predict(data, classifier):
+def predict(data, saved_model):
     """
     Args:
       data: (n, m) array of features where n is the number of examples
             and m is the number of features.
-      classifier: a SavedModelPredictor with an input tensor 'input' that
+      saved_model: a SavedModelPredictor with an input tensor 'input' that
                   expects as input a list of tf.train.Example's.
     Returns:
       scores: (n, num_classes) array of scores for each each class
     """
     model_inputs = []
 
-    for d in data:
+    for i, d in enumerate(data):
         input = tf.train.Example(
             features=tf.train.Features(
                 feature={
@@ -49,24 +51,25 @@ def predict(data, classifier):
 
         model_inputs.append(input.SerializeToString())
 
-    output_dict = classifier({'inputs': model_inputs})
+    output_dict = saved_model({'inputs': model_inputs})
     scores = output_dict['scores']
 
     return scores
 
 def load_model(session, model_dir):
-    """Loads SavedModel model and returns classifier."""
+
+    """Loads SavedModelPredictor model"""
     tf.saved_model.loader.load(
         session, [tf.saved_model.tag_constants.SERVING], model_dir)
 
-    classifier = tf.contrib.predictor.from_saved_model(model_dir)
+    saved_model = tf.contrib.predictor.from_saved_model(model_dir)
 
-    return classifier
+    return saved_model
 
 def main():
 
     with tf.Session(graph=tf.Graph()) as sess:
-        classifier = load_model(sess, FLAGS.model_dir)
+        saved_model = load_model(sess, FLAGS.model_dir)
 
     # load test data
     data = wikidata.WikiData(
@@ -76,19 +79,30 @@ def main():
         predict_mode=True)
 
     # evaluate model on data
-    # TODO: For now, this just prints out the 10 first examples.
-    #       This isn't very useful.
-    test_data = data.x_test[0:10]
-    scores = predict(test_data, classifier)
+    x_to_eval = data.x_test[0:FLAGS.n_examples]
+    scores = predict(x_to_eval, saved_model)
 
-    for i in range(len(scores)):
-        print(scores[i][0], data.x_test_text[i])
+    results = {
+        'results': [
+            {
+                'score': float(scores[i][0]),
+                'text': data.x_test_text[i]
+            } for i in range(len(scores))]
+    }
 
+    # write results to model directory
+    output_path = '{0}predictions_{1}.json'.format(FLAGS.model_dir, FLAGS.n_examples)
+    f = open(output_path, 'w')
+    f.write(json.dumps(results))
+
+    tf.logging.info('Wrote predictions to {0}'.format(output_path))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--test_data', help='Path to data to evaluate on.', type=str)
     parser.add_argument('--model_dir', help='Path to directory with TF model.', type=str)
+    parser.add_argument('--n_examples', help='Number of examples to evaluate.',
+                        type=int, default=100)
 
     FLAGS, unparsed = parser.parse_known_args()
 

--- a/kaggle-classification/trainer/eval.py
+++ b/kaggle-classification/trainer/eval.py
@@ -9,12 +9,14 @@ python trainer/eval.py  \
   --model_dir=saved_models/{timestamp}/ \
   --test_data=local_data/test.csv
 """
-
+import sys
 import argparse
 import numpy as np
 import pandas as pd
-import wikidata
 import tensorflow as tf
+
+sys.path.insert(0, '')
+from trainer import wikidata
 
 # Name of the input words feature
 WORDS_FEATURE = 'words'
@@ -80,7 +82,7 @@ def main():
     scores = predict(test_data, classifier)
 
     for i in range(len(scores)):
-        print scores[i][0], data.x_test_text[i]
+        print(scores[i][0], data.x_test_text[i])
 
 
 if __name__ == '__main__':

--- a/kaggle-classification/trainer/eval.py
+++ b/kaggle-classification/trainer/eval.py
@@ -1,12 +1,12 @@
 """
 Evaluates a model on data. Takes a path to a directory with a TensorFlow
-SavedModel and a path to a CSV with data, and outputs the predictions of the
-model on the data.
+SavedModel and a path to a CSV with data, and writes the predictions of the
+model on the data to the same directory as the provided model_dir.
 
 Example usage:
 
 python trainer/eval.py  \
-  --model_dir=saved_models/{timestamp}/ \
+  --model_dir={path_to_saved_model}/ \
   --test_data=local_data/test.csv
   --n_examples=1000
 """
@@ -57,7 +57,6 @@ def predict(data, saved_model):
     return scores
 
 def load_model(session, model_dir):
-
     """Loads SavedModelPredictor model"""
     tf.saved_model.loader.load(
         session, [tf.saved_model.tag_constants.SERVING], model_dir)

--- a/kaggle-classification/trainer/model.py
+++ b/kaggle-classification/trainer/model.py
@@ -332,6 +332,7 @@ def main(FLAGS):
     export_path = classifier.export_savedmodel(FLAGS.job_dir, serving_input_fn)
     data.save_vocab_processor(export_path)
 
+
 if __name__ == '__main__':
 
   parser = argparse.ArgumentParser()

--- a/kaggle-classification/trainer/model.py
+++ b/kaggle-classification/trainer/model.py
@@ -199,7 +199,7 @@ def get_cnn_model(embedding_size, num_filters, dropout_keep_prob):
       scores = tf.nn.xw_plus_b(h_drop, W, b, name="scores")
 
     return estimator_spec_for_softmax_classification(
-      logits=scores, labels=labels, mode=mode, learning_rate = FLAGS.learning_rate)
+      logits=scores, labels=labels, mode=mode, learning_rate=FLAGS.learning_rate)
   return cnn_model
 
 def bag_of_words_model(features, labels, mode):
@@ -224,7 +224,7 @@ def bag_of_words_model(features, labels, mode):
   logits = tf.layers.dense(bow, MAX_LABEL, activation=None)
 
   return estimator_spec_for_softmax_classification(
-      logits=logits, labels=labels, mode=mode)
+      logits=logits, labels=labels, mode=mode, learning_rate=FLAGS.learning_rate)
 
 def main(FLAGS):
     global n_words

--- a/kaggle-classification/trainer/wikidata.py
+++ b/kaggle-classification/trainer/wikidata.py
@@ -9,6 +9,8 @@ import tflearn
 from sklearn.model_selection import train_test_split
 
 Y_CLASSES = ['toxic', 'severe_toxic','obscene','threat','insult','identity_hate']
+TEXT_FIELD = 'comment_text'
+VOCAB_PROCESSOR_FILENAME = 'vocab_processor'
 
 
 def ngrams(sentence, ngram_size):
@@ -24,20 +26,18 @@ def ngrams(sentence, ngram_size):
 
 class WikiData:
 
-  def __init__(self, data_path, y_class, max_document_length,
-               vocab_processor_path=None, test_mode=False, seed=None,
-               train_percent=None, char_ngrams=None, min_frequency=None):
+  def __init__(self, data_path, max_document_length, y_class=None,
+               model_dir=None, predict_mode=False, seed=None, train_percent=None,
+               char_ngrams=None, min_frequency=None):
     """
     Args:
       * data_path (string): path to file containing train or test data
+      * max_document_length (int): max number of tokens per document
       * y_class (string): the class we're training or testing on
-      * vocab_processor_path (string): if provided, the comment_text data will
-          be processed with the vocab processor at that location. If not, a new
-          vocab_processor will be created using the training data.
-      * test_mode (boolean): true if loading data just to test on, not training
-                             a model
+      * model_dir (string): directory with model files
+      * predict_mode (boolean): true if loading data just to predict on
       * seed (integer): a random seed to use for data splitting
-      * train_percent (fload): the percent of data we should use for training data
+      * train_percent (float): the percent of data we should use for training data
     """
     data = self._load_csv(data_path)
 
@@ -47,42 +47,59 @@ class WikiData:
     self.y_test = None
     self.vocab_processor = None
 
-    # If test_mode is True, then put all the data in x_test and y_test
-    if test_mode:
-      train_percent = 0
+    # -- predict mode
+    if predict_mode:
+      # Assume no labels, put all the data in x_test_text and x_test
+      self.x_test_text = data[TEXT_FIELD]
+
+      # Load cached VocabularyProcessor
+      self.vocab_processor = self._load_vocab_processor(model_dir)
+
+      # Process the test data
+      self.x_test = np.array(list(self.vocab_processor.transform(self.x_test_text)))
+
+      return
+
+    # -- train mode
 
     # Split the data into test / train sets
     self.x_train_text, self.x_test_text, self.y_train, self.y_test \
-      = self._split(data, train_percent, 'comment_text', y_class, seed)
+      = self._split(data, train_percent, TEXT_FIELD, y_class, seed)
 
-    # Either load a VocabularyProcessor or compute one from the training data
-    if test_mode:
+    tokenizer_fn = None
+    if char_ngrams:
+      tokenizer_fn=lambda iterator: (ngrams(x, char_ngrams) for x in iterator)
 
-      # If test_mode is True and no vocab_processor_path is specified, then
-      # return an error. We shouldn't train a VocabProcessor at test time.
-      if vocab_processor_path is None:
-        tf.logging.error("Loading data in test_mode with no vocab_processor_path")
-        raise ValueError
+    # Create a VocabularyProcessor from the training data
+    self.vocab_processor = tflearn.data_utils.VocabularyProcessor(
+      max_document_length=max_document_length, min_frequency=min_frequency,
+      tokenizer_fn=tokenizer_fn)
 
-      self.vocab_processor = self.load_vocab_processor(vocab_processor_path)
-
-    else:
-      tokenizer_fn = None
-      if char_ngrams:
-        tokenizer_fn=lambda iterator: (ngrams(x, char_ngrams) for x in iterator)
-      self.vocab_processor = tflearn.data_utils.VocabularyProcessor(
-        max_document_length=max_document_length, min_frequency=min_frequency,
-        tokenizer_fn=tokenizer_fn)
-      self.x_train = np.array(list(self.vocab_processor.fit_transform(
-        self.x_train_text)))
+    self.x_train = np.array(list(self.vocab_processor.fit_transform(
+      self.x_train_text)))
 
     # Apply the VocabularyProcessor to the test data
     self.x_test = np.array(list(self.vocab_processor.transform(
       self.x_test_text)))
 
-  def _load_vocab_processor(self, path):
-    """Load a VocabularyProcessor from the provided path"""
-    return tflearn.data_utils.VocabularyProcessor.restore(path)
+  def _load_vocab_processor(self, model_dir):
+    """Load a VocabularyProcessor from the provided directory"""
+    vocab_processor_path = self._vocab_processor_path(model_dir)
+    tf.logging.info('Loading VocabularyProcessor from {}'.format(vocab_processor_path))
+
+    return tf.contrib.learn.preprocessing.VocabularyProcessor.restore(vocab_processor_path)
+
+  def save_vocab_processor(self, model_dir):
+    """Save a VocabularyProcessor in the provided directory"""
+    vocab_processor_path = self._vocab_processor_path(model_dir)
+    tf.logging.info('Saving VocabularyProcessor to {}'.format(vocab_processor_path))
+
+    tf.contrib.learn.preprocessing.VocabularyProcessor.save(
+      self.vocab_processor, vocab_processor_path)
+
+  def _vocab_processor_path(self, model_dir):
+    """Retruns the path to the file containing a trained VocabularyProcessor"""
+    return model_dir + '/' + VOCAB_PROCESSOR_FILENAME
 
   def _load_csv(self, path):
     """

--- a/kaggle-classification/trainer/wikidata.py
+++ b/kaggle-classification/trainer/wikidata.py
@@ -13,15 +13,19 @@ TEXT_FIELD = 'comment_text'
 VOCAB_PROCESSOR_FILENAME = 'vocab_processor'
 
 
-def ngrams(sentence, ngram_size):
-  """Converts a string into a list of ngrams of characters.
+class Ngrams:
+  def __init__(self, ngram_size):
+    self.ngram_size = ngram_size
 
-  ngrams('abra cadabra', 5) =
-    [('a', 'b', 'r', 'a', ' '), ('b', 'r', 'a', ' ', 'c'), ...
-     ('a', 'd', 'a', 'b', 'r'), ('d', 'a', 'b', 'r', 'a')]
-  """
-  chars = list(sentence)
-  return zip(*[chars[i:] for i in range(ngram_size)])
+  def __call__(self, iterator):
+    """Converts a string into a list of ngrams of characters.
+
+    list(ngrams(['abra cadabra'], 5)) =
+      [('a', 'b', 'r', 'a', ' '), ('b', 'r', 'a', ' ', 'c'), ...
+       ('a', 'd', 'a', 'b', 'r'), ('d', 'a', 'b', 'r', 'a')]
+    """
+    return (zip(*[list(x)[i:] for i in range(self.ngram_size)])
+            for x in iterator)
 
 
 class WikiData:
@@ -68,7 +72,7 @@ class WikiData:
 
     tokenizer_fn = None
     if char_ngrams:
-      tokenizer_fn=lambda iterator: (ngrams(x, char_ngrams) for x in iterator)
+      tokenizer_fn=Ngrams(char_ngrams)
 
     # Create a VocabularyProcessor from the training data
     self.vocab_processor = tflearn.data_utils.VocabularyProcessor(


### PR DESCRIPTION
The goal here is to be able to train a model, save it and then later load the model and run new data through it. This sequence involves saving the `VocabularyProcessor` to disk and pre-processing the new data using it. 

WikiData now takes a `predict_mode` flag. If `predict_mode=True`, then we process the data using a pre-trained `VocabularyProcessor`. 

**To Test**
```
./bin/run_local
python trainer/eval.py --model_dir=[path-to-saved-model] --test_data=local_data/test.csv
```

Right now, `eval.py` just prints out the predictions for the first 10 examples. This is not very useful for now, but we can make it more useful in the future. 

