### PR TITLE
[Tiny] Change ls-jobs to only show user's jobs

### DIFF
--- a/annotator-models/bin/ls-jobs
+++ b/annotator-models/bin/ls-jobs
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-DATE=`date '+%Y-%m-%d'`
-
-gcloud ml-engine jobs list | grep $DATE
+gcloud ml-engine jobs list | grep $USER


### PR DESCRIPTION
The old functionality of the ls-jobs script printed out all the jobs started that day. I've been finding that what I really want is all _my_ jobs, regardless of what day they started. 

@nthain, @jjtan: This is only a change to the bin/ls-jobs script in the annotator-models directory, but I can change it everywhere if you want.