### PR TITLE
Improve output of the dawid-skene trainer 

### DIFF
--- a/annotator-models/bin/run
+++ b/annotator-models/bin/run
@@ -6,8 +6,6 @@
 # To run with default hyperparameters from the kaggle-classification directory just enter:
 # './bin/run'
 #
-# To run with hyperparameter tuning, enter:
-# './bin/run -c hparam_config.yaml'
 #
 #
 # Setup Steps:
@@ -19,15 +17,18 @@
 # Edit these!
 BUCKET_NAME=annotator_models
 CONFIG=cpu_config.yaml
-JOB_NAME=${USER}_kaggle_training
 LABEL=toxic_score
 MAX_ITER=50
+DATA_PATH=gs://annotator_models/dawid_skene_training_data_100k.csv
 
 # Note: this must be compatible with cells that have GPUs. us-central1 works.
 # See: https://cloud.google.com/ml-engine/docs/using-gpus
 REGION=us-central1
 DATE=`date '+%Y%m%d_%H%M%S'`
-OUTPUT_PATH=gs://${BUCKET_NAME}/models/${USER}/${DATE}_${LABEL}
+DATE_DAY_ONLY=`date '+%Y%m%d'`
+JOB_NAME=${USER}_dawid_skene_${LABEL}
+OUTPUT_PATH=gs://${BUCKET_NAME}/models/${USER}/${DATE_DAY_ONLY}
+COMMENT_TEXT_PATH=gs://${BUCKET_NAME}/q42017_comment_text.csv
 
 while getopts :c:h opt; do
 case ${opt} in
@@ -54,13 +55,14 @@ echo "Writing to $OUTPUT_PATH"
 
 # Remote
 gcloud ml-engine jobs submit training ${JOB_NAME}_${DATE} \
-     --job-dir ${OUTPUT_PATH} \
-     --runtime-version 1.4 \
-     --config ${CONFIG} \
+     --job-dir=${OUTPUT_PATH} \
+     --runtime-version=1.4 \
+     --config=${CONFIG} \
      --module-name=trainer.dawid_skene \
      --package-path=trainer \
-     --region $REGION \
-     --verbosity debug -- \
-     --data-path=gs://annotator_models/dawid_skene_training_data_100k.csv \
+     --region=$REGION \
+     --verbosity=debug -- \
+     --data-path=$DATA_PATH \
+     --comment-text-path=$COMMENT_TEXT_PATH \
      --label=$LABEL \
      --max-iter=$MAX_ITER

--- a/annotator-models/bin/run_local
+++ b/annotator-models/bin/run_local
@@ -7,12 +7,18 @@
 #!/bin/bash
 
 DATE=`date '+%Y%m%d_%H%M%S'`
-BUCKET_NAME=annotator_models
+
+# the path to the CSV with the rating data
+DATA_PATH=gs://annotator_models/dawid_skene_training_data_100k.csv
+
+# the path to the CSV with the full comment text
+COMMENT_TEXT_PATH=gs://annotator_models/q42017_comment_text.csv
 
 gcloud ml-engine local train \
      --module-name=trainer.dawid_skene \
      --package-path=trainer -- \
-     --data-path=gs://${BUCKET_NAME}/dawid_skene_training_data_10k.csv \
-     --label='toxic_score' \
+     --data-path=$DATA_PATH \
+     --comment-text-path=$COMMENT_TEXT_PATH \
+     --label='obscene' \
      --job-dir='results' \
      --max-iter=10

--- a/annotator-models/trainer/dawid_skene.py
+++ b/annotator-models/trainer/dawid_skene.py
@@ -454,13 +454,13 @@ def parse_error_rates(df, error_rates, index_to_worker_id_map, index_to_y_map):
 
     df_error_rates = pd.merge(df_error_rates, worker_counts, on='_worker_id')
 
-    # add the diagonal error rates, i.e. for each class k, add a column
-    # for p(rater will pick k | the item's true class is k)
-    #
+    # add the diagonal error rates, which are the per-class accuracy rates,
+    # for each class k, we add a column for p(rater will pick k | item's true class is k)
+
     # y_label is the original y value in the data and y_index is the
-    # integer we mapped it tto, i.e. 0, 1, ..., |Y|
+    # integer we mapped it to, i.e. 0, 1, ..., |Y|
     for y_index, y_label in index_to_y_map.items():
-        col_name = 'error_rate_{0}_{0}'.format(y_label)
+        col_name = 'accuracy_rate_{0}'.format(y_label)
         df_error_rates[col_name] = [e[y_index, y_index] for e in error_rates]
 
     return df_error_rates


### PR DESCRIPTION
The output of running the dawid-skene trainer is:

* the predicted labels - A file with the per-item predictions, (eg `predictions_obscene_100000.json`) that contains the comment id (`_unit_id`), the mean score from the original data (`obscene_mean`) and predicted probability for each class (`obscene_hat_0`, `obscene_hat_1`).

* the predicted error rates - A file that has the per-rater error rates. Instead of including the full `nClasses x nClasses` error rate matrix, I'm only including the values on the diagonal. I got myself turner around yesterday, because the diagonal error rates are actually accuracy rates (i.e. probability of correctly predicting class k if the true class was k).

This change improves these outputs by 1) updating the column names of the diagonal error rates to per class "accuracy_rates"  and 2) adds the original `comment_text` to the file of predicted labels so we can do analysis on the results without having to join the data in BQ. 

### To test 
Locally, `./bin/run_local`. The output will be written to a local `results` directory.

On ml-engine, `./bin/run`. The output will be written to a Cloud Storage bucket. 

