### PR TITLE
[Tiny] Update default dawid-skene tolerance

### DIFF
--- a/annotator-models/trainer/dawid_skene.py
+++ b/annotator-models/trainer/dawid_skene.py
@@ -23,7 +23,7 @@ import time
 FLAGS = None
 np.set_printoptions(precision=2)
 
-def run(items, raters, classes, counts, label, tol=0.1, max_iter=25, init='average'):
+def run(items, raters, classes, counts, label, tol=1, max_iter=25, init='average'):
     """
     Run the Dawid-Skene estimator on response data
 


### PR DESCRIPTION
The stopping condition for the dawid-skene code is

```python
if (class_marginals_diff < tol and item_class_diff < tol)
```

That means the sum of the difference in the predicted class distributions need to be less than `tol`. We're running this on hundreds of thousands of examples, so .1 seems far too low. 