### PR TITLE
Rename validation_path flag to test_path

### DIFF
--- a/kaggle-classification/bin/run_keras.sh
+++ b/kaggle-classification/bin/run_keras.sh
@@ -34,7 +34,7 @@ gcloud ml-engine jobs submit training ${JOB_NAME}_${DATE} \
     --config ${HPARAM_CONFIG} \
     -- \
     --train_path ${INPUT_PATH}/train.csv \
-    --validation_path ${INPUT_PATH}/validation.csv \
+    --test_path ${INPUT_PATH}/validation.csv \
     --embeddings_path ${INPUT_PATH}/glove.6B/glove.6B.100d.txt \
     --log_path ${LOG_PATH}
 

--- a/kaggle-classification/bin/run_keras_local.sh
+++ b/kaggle-classification/bin/run_keras_local.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 DATE=`date '+%Y%m%d_%H%M%S'`
 OUTPUT_PATH=runs/${DATE}
@@ -17,7 +18,7 @@ echo ""
 
 python -m keras_trainer.model \
 	--train_path=${INPUT_PATH}/train.csv \
-	--validation_path=${INPUT_PATH}/validation.csv \
+	--test_path=${INPUT_PATH}/validation.csv \
 	--embeddings_path=${INPUT_PATH}/glove.6B/glove.6B.100d.txt \
 	--job-dir=${OUTPUT_PATH} \
 	--log_path=${LOG_PATH}

--- a/kaggle-classification/keras_trainer/model.py
+++ b/kaggle-classification/keras_trainer/model.py
@@ -57,7 +57,7 @@ LABELS = ['toxic', 'severe_toxic', 'obscene', 'threat', 'insult', 'identity_hate
 
 class ModelRunner():
   """Toxicity model using CNN + Attention"""
-  
+
   def __init__(self,
                job_dir,
                embeddings_path,
@@ -108,7 +108,7 @@ class ModelRunner():
     tf.gfile.Copy(TEMPORARY_MODEL_PATH, self.model_path, overwrite=True)
     tf.gfile.Remove(TEMPORARY_MODEL_PATH)
     print('Saved model to {}'.format(self.model_path))
-    
+
     self._load_model()
 
   def predict(self, texts):
@@ -166,7 +166,7 @@ if __name__ == '__main__':
   parser.add_argument(
       '--train_path', type=str, default='local_data/train.csv', help='Path to the training data.')
   parser.add_argument(
-      '--validation_path', type=str, default='local_data/validation.csv', help='Path to the test data.')
+      '--test_path', type=str, default='local_data/validation.csv', help='Path to the test data.')
   parser.add_argument(
       '--embeddings_path', type=str, default='local_data/glove.6B/glove.6B.100d.txt', help='Path to the embeddings.')
   parser.add_argument(
@@ -204,7 +204,7 @@ if __name__ == '__main__':
     train = pd.read_csv(f, encoding='utf-8')
   model.train(train)
 
-  with tf.gfile.Open(FLAGS.validation_path, 'rb') as f:
+  with tf.gfile.Open(FLAGS.test_path, 'rb') as f:
     test_data = pd.read_csv(f, encoding='utf-8')
   model.score_auc(test_data)
 


### PR DESCRIPTION
This change renames the `--validation_path` flag to `--test_path` for the keras model. It turns out that data was not used for validation during training. It's only used to calculate the final AUC score. Which is as it should be, but we should rename the flag to reflect that. 