### PR TITLE
Simplify Attention Network in RNN + Allow run scripts to handle no comet_key

### DIFF
--- a/kaggle-classification/bin/run_keras.sh
+++ b/kaggle-classification/bin/run_keras.sh
@@ -27,20 +27,20 @@ echo "Writing to $OUTPUT_PATH"
 
 # Remote
 gcloud ml-engine jobs submit training ${JOB_NAME}_${DATE} \
-    --job-dir $OUTPUT_PATH \
-    --runtime-version 1.4 \
-    --module-name keras_trainer.model \
-    --package-path keras_trainer \
-    --region $REGION \
-    --verbosity debug \
-    --config ${HPARAM_CONFIG} \
+    --job-dir=$OUTPUT_PATH \
+    --runtime-version=1.4 \
+    --module-name=keras_trainer.model \
+    --package-path=keras_trainer \
+    --region=$REGION \
+    --verbosity=debug \
+    --config=${HPARAM_CONFIG} \
     -- \
-    --train_path ${INPUT_PATH}/train.csv \
-    --test_path ${INPUT_PATH}/validation.csv \
-    --embeddings_path ${INPUT_PATH}/glove.6B/glove.6B.100d.txt \
-    --log_path ${LOG_PATH} \
-    --comet_key ${COMET_KEY} \
-    --model_type rnn
+    --train_path=${INPUT_PATH}/train.csv \
+    --test_path=${INPUT_PATH}/validation.csv \
+    --embeddings_path=${INPUT_PATH}/glove.6B/glove.6B.100d.txt \
+    --log_path=${LOG_PATH} \
+    --comet_key=${COMET_KEY} \
+    --model_type=rnn
 
 echo "You can view the tensorboard for this job with the command:"
 echo ""

--- a/kaggle-classification/bin/run_keras_local.sh
+++ b/kaggle-classification/bin/run_keras_local.sh
@@ -19,10 +19,10 @@ echo "This will populate after a model checkpoint is saved."
 echo ""
 
 python -m keras_trainer.model \
-	--train_path=${INPUT_PATH}/train.csv \
-	--validation_path=${INPUT_PATH}/validation.csv \
-	--embeddings_path=${INPUT_PATH}/glove.6B/glove.6B.100d.txt \
-	--job-dir=${OUTPUT_PATH} \
-	--log_path=${LOG_PATH} \
-	--comet_key ${COMET_KEY} \
-  --model_type=rnn
+       --train_path=${INPUT_PATH}/train.csv \
+       --test_path=${INPUT_PATH}/validation.csv \
+       --embeddings_path=${INPUT_PATH}/glove.6B/glove.6B.100d.txt \
+       --job-dir=${OUTPUT_PATH} \
+       --log_path=${LOG_PATH} \
+       --comet_key=${COMET_KEY} \
+       --model_type=rnn

--- a/kaggle-classification/keras_trainer/model.py
+++ b/kaggle-classification/keras_trainer/model.py
@@ -30,7 +30,6 @@ from keras_trainer.single_layer_cnn import SingleLayerCnn
 from keras_trainer.rnn import RNNModel
 from keras_trainer.custom_metrics import auc_roc
 
-
 FLAGS = None
 
 TEMPORARY_MODEL_PATH = 'model.h5'
@@ -189,9 +188,17 @@ if __name__ == '__main__':
   parser.add_argument(
       '--job-dir', type=str, default='local_data/', help='Path to model file.')
   parser.add_argument(
-      '--log_path', type=str, default='local_data/logs/', help='Path to write tensorboard logs.')
+      '--log_path',
+      type=str,
+      default='local_data/logs/',
+      help='Path to write tensorboard logs.')
   parser.add_argument(
-      '--comet_key', type=str, default=None, help='Path to file containing comet.ml api key. Set to None to disable comet.ml.')
+      '--comet_key',
+      type=str,
+      default=None,
+      help=
+      'Path to file containing comet.ml api key. Set to None to disable comet.ml.'
+  )
   parser.add_argument(
       '--labels',
       default='toxic,severe_toxic,obscene,threat,insult,identity_hate',
@@ -208,7 +215,6 @@ if __name__ == '__main__':
       '--dropout_rate', type=float, default=0.5, help='Dropout rate.')
   parser.add_argument('--batch_size', default=64, help='Batch size.')
 
-
   FLAGS = parser.parse_args()
 
   hparams = DEFAULT_HPARAMS
@@ -218,10 +224,11 @@ if __name__ == '__main__':
   hparams.model_type = FLAGS.model_type
 
   if FLAGS.comet_key:
-    experiment = Experiment(api_key=FLAGS.comet_key, 
-      project_name='comet_trial_run', 
-      auto_param_logging=False,
-      parse_args=False)
+    experiment = Experiment(
+        api_key=FLAGS.comet_key,
+        project_name='comet_trial_run',
+        auto_param_logging=False,
+        parse_args=False)
     experiment.log_multiple_params(hparams.values())
     experiment.log_parameter('test_data_path', FLAGS.train_path)
     experiment.log_parameter('valid_data_path', FLAGS.validation_path)
@@ -252,6 +259,6 @@ if __name__ == '__main__':
   with tf.gfile.Open(FLAGS.test_path, 'rb') as f:
     test_data = pd.read_csv(f, encoding='utf-8')
   if FLAGS.comet_key:
-    experiment.log_metric("test_auc", model.score_auc(test_data))
+    experiment.log_metric('test_auc', model.score_auc(test_data))
 
   model.predict(['This sentence is benign'])

--- a/kaggle-classification/keras_trainer/model.py
+++ b/kaggle-classification/keras_trainer/model.py
@@ -213,7 +213,7 @@ if __name__ == '__main__':
       '--learning_rate', type=float, default=0.00005, help='Learning rate.')
   parser.add_argument(
       '--dropout_rate', type=float, default=0.5, help='Dropout rate.')
-  parser.add_argument('--batch_size', default=64, help='Batch size.')
+  parser.add_argument('--batch_size', type=int, default=64, help='Batch size.')
 
   FLAGS = parser.parse_args()
 

--- a/kaggle-classification/keras_trainer/rnn.py
+++ b/kaggle-classification/keras_trainer/rnn.py
@@ -35,10 +35,11 @@ class RNNModel(base_model.BaseModel):
         trainable=self.hparams.train_embedding)(
             I)
     H = Bidirectional(GRU(128, return_sequences=True))(E)
-    A = TimeDistributed(Dense(3), input_shape=(sequence_length, 256))(H)
-    A = Flatten()(A)
-    A = Dense(sequence_length, activation='softmax')(A)
+    A = TimeDistributed(
+        Dense(1, activation='softmax'), input_shape=(sequence_length, 256))(
+            H)
     X = Dot((1, 1))([H, A])
+    X = Flatten()(X)
     X = Dense(128, activation='relu')(X)
     X = Dropout(self.hparams.dropout_rate)(X)
     Output = Dense(6, activation='sigmoid')(X)

--- a/kaggle-classification/keras_trainer/tfrecord_batch_generator.py
+++ b/kaggle-classification/keras_trainer/tfrecord_batch_generator.py
@@ -1,0 +1,44 @@
+"""TODO(jjtan): DO NOT SUBMIT without one-line documentation for batch_generator.
+
+TODO(jjtan): DO NOT SUBMIT without a detailed description of batch_generator.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from collections.abc import Generator
+import tensorflow as tf
+
+
+class TFRecordBatchGenerator(Generator):
+  """Batch Generator
+  """
+
+  def __init__(self, tfrecord_file):
+    dataset = tf.data.TFRecordDataset(filenames=tfrecord_file)
+    dataset = dataset.map(self._parse_function)
+    dataset = dataset.batch(4)  # Batch size to use
+    self.example_itr = dataset.make_one_shot_iterator()
+
+  def send(self, ignored_arg):
+    examples = self.example_itr.get_next()
+    return examples
+
+  def throw(self):
+    raise StopIteration
+
+  def _parse_function(self, serialized):
+    features = {
+        'comment_text': tf.FixedLenFeature([], tf.string),
+        'frac_neg': tf.FixedLenFeature([], tf.float32),  # toxic
+        'frac_very_neg': tf.FixedLenFeature([], tf.float32),  # severe_toxic
+        'obscene': tf.FixedLenFeature([], tf.float32),
+        'threat': tf.FixedLenFeature([], tf.float32),
+        'insult': tf.FixedLenFeature([], tf.float32),
+        'identity_hate': tf.FixedLenFeature([], tf.float32)
+    }
+    # Parse the serialized data so we get a dict with our data.
+    parsed_example = tf.parse_single_example(
+        serialized=serialized, features=features)
+    return parsed_example

--- a/kaggle-classification/keras_trainer/tfrecord_batch_generator.py
+++ b/kaggle-classification/keras_trainer/tfrecord_batch_generator.py
@@ -15,6 +15,11 @@ class TFRecordBatchGenerator(Generator):
   """Batch Generator
   """
 
+  TARGETS = [
+      'frac_neg', 'frac_very_neg', 'obscene', 'threat', 'insult',
+      'identity_hate'
+  ]
+
   def __init__(self, tfrecord_file):
     dataset = tf.data.TFRecordDataset(filenames=tfrecord_file)
     dataset = dataset.map(self._parse_function)
@@ -31,13 +36,10 @@ class TFRecordBatchGenerator(Generator):
   def _parse_function(self, serialized):
     features = {
         'comment_text': tf.FixedLenFeature([], tf.string),
-        'frac_neg': tf.FixedLenFeature([], tf.float32),  # toxic
-        'frac_very_neg': tf.FixedLenFeature([], tf.float32),  # severe_toxic
-        'obscene': tf.FixedLenFeature([], tf.float32),
-        'threat': tf.FixedLenFeature([], tf.float32),
-        'insult': tf.FixedLenFeature([], tf.float32),
-        'identity_hate': tf.FixedLenFeature([], tf.float32)
     }
+    for target in TARGETS:
+      features[target] = tf.FixedLenFeature([], tf.float32)
+
     # Parse the serialized data so we get a dict with our data.
     parsed_example = tf.parse_single_example(
         serialized=serialized, features=features)


### PR DESCRIPTION
Note: It seems that using the '=' syntax when specifying flags will treat the empty string as empty string, whereas without it is not specified.