### PR TITLE
Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is contains example code to train machine learning models for te
 
 # Outline of the codebase
 
-* `experiments/` contains the conversation AI ML training framework.
+* `experiments/` contains the ML training framework.
 * `annotator-models/` contains a Dawid-Skene implementation for modelling rater quality to produce better annotations.
 * `attention-colab/` contains an introductory ipython notebook for RNNs with attention, as presented at Devoxx talk ["Tensorflow, deep learning and modern RNN architectures, without a PhD by Martin Gorner"](https://www.youtube.com/watch?v=pzOzmxCR37I)
 * `kaggle-classification/` early experiments with Keras and Estimator for training on [the Jigsaw Toxicity Kaggle competition](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge). Will be superceeded by `experiments/` shortly.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is contains example code to train machine learning models for te
 
 # Outline of the codebase
 
-* `experiments/` contains out ML training framework.
+* `experiments/` contains the conversation AI ML training framework.
 * `annotator-models/` contains a Dawid-Skene implementation for modelling rater quality to produce better annotations.
 * `attention-colab/` contains an introductory ipython notebook for RNNs with attention, as presented at Devoxx talk ["Tensorflow, deep learning and modern RNN architectures, without a PhD by Martin Gorner"](https://www.youtube.com/watch?v=pzOzmxCR37I)
 * `kaggle-classification/` early experiments with Keras and Estimator for training on [the Jigsaw Toxicity Kaggle competition](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge). Will be superceeded by `experiments/` shortly.


### PR DESCRIPTION
I would have suggested "out" to be "our" as the most readily available fix, but open source ownership trickier than that. You could state it as "our" and sound closed to contributes, "your" and make the project sound like an abandoned code dump, or "the result of core team and community contributions", which is both verbose and makes an "us vs them" comparison for contributors, etc. Thus I chose to describe the model as a component of the project rather than a component owned by some group of people.