### PR TITLE
Adding serving function for tf_records with unknown batch size.

### DIFF
--- a/experiments/tf_trainer/common/serving_input.py
+++ b/experiments/tf_trainer/common/serving_input.py
@@ -9,8 +9,9 @@ from tensorflow.python.ops import array_ops
 
 FLAGS = tf.app.flags.FLAGS
 
-tf.app.flags.DEFINE_boolean("use_tfrecords_for_serving", True,
-                            "Use tfrecords as format for serving.")
+tf.app.flags.DEFINE_string("serving_format", "TFRECORDS",
+                           "Format of inputs in inference."
+                           "Can be either JSON or TFRECORDS.")
 
 
 def create_serving_input_fn(feature_preprocessor_init, text_feature_name, key_name):
@@ -53,7 +54,11 @@ def create_serving_input_fn(feature_preprocessor_init, text_feature_name, key_na
         features,
         serialized_example)
   
-  if FLAGS.use_tfrecords_for_serving:
+  if FLAGS.serving_format == 'TFRECORDS':
     return serving_input_fn_tfrecords
-  else:
+  elif FLAGS.serving_format == 'JSON':
     return serving_input_fn_json
+  else:
+    raise ValueError('Serving format not implemented.'
+        ' Should be one of ["JSON", "TFRECORDS"].'
+        )

--- a/experiments/tf_trainer/common/serving_input.py
+++ b/experiments/tf_trainer/common/serving_input.py
@@ -7,9 +7,15 @@ from __future__ import print_function
 import tensorflow as tf
 from tensorflow.python.ops import array_ops
 
+FLAGS = tf.app.flags.FLAGS
+
+tf.app.flags.DEFINE_boolean("use_tfrecords_for_serving", True,
+                            "Use tfrecords as format for serving.")
+
+
 def create_serving_input_fn(feature_preprocessor_init, text_feature_name, key_name):
 
-  def serving_input_fn():
+  def serving_input_fn_json():
     features_placeholders = {}
     features_placeholders[text_feature_name] = array_ops.placeholder(
         dtype=tf.string, name=text_feature_name)
@@ -26,4 +32,28 @@ def create_serving_input_fn(feature_preprocessor_init, text_feature_name, key_na
         features,
         features_placeholders)
 
-  return serving_input_fn
+  def serving_input_fn_tfrecords():
+    serialized_example = tf.placeholder(
+        shape=[None],
+        dtype=tf.string,
+        name="input_example_tensor"
+    )
+    feature_spec = {
+        text_feature_name: tf.FixedLenFeature([], dtype=tf.string),
+        key_name: tf.FixedLenFeature([], dtype=tf.int64)
+    }
+
+    features = tf.parse_example(
+        serialized_example, feature_spec)
+    feature_preprocessor = feature_preprocessor_init()
+    features[text_feature_name] = feature_preprocessor(
+        features[text_feature_name])
+
+    return tf.estimator.export.ServingInputReceiver(
+        features,
+        serialized_example)
+  
+  if FLAGS.use_tfrecords_for_serving:
+    return serving_input_fn_tfrecords
+  else:
+    return serving_input_fn_json

--- a/experiments/tf_trainer/common/text_preprocessor.py
+++ b/experiments/tf_trainer/common/text_preprocessor.py
@@ -34,7 +34,7 @@ class TextPreprocessor(object):
         TextPreprocessor._get_word_idx_and_embeddings(
             embeddings_path)  # type: Tuple[Dict[str, int], np.ndarray, int]
 
-  def tokenize_tensor_op_tf_func(self) -> Callable[[types.Tensor], types.Tensor]:
+  def tokenize_tensor_op_tf_func(self, single_record_level=False) -> Callable[[types.Tensor], types.Tensor]:
     """Tensor op that converts some text into an array of ints that correspond
     with this preprocessor's embedding.
 
@@ -62,7 +62,10 @@ class TextPreprocessor(object):
 
       # TODO: Improve tokenizer.
       # TODO: Ensure utf-8 encoding. Currently the string is parsed with default encoding (unclear). 
-      words = tf.string_split([text])
+      if single_record_level:
+        words = tf.string_split([text])
+      else:
+        words = tf.string_split(text)
       words_int_sparse = vocabulary_table.lookup(words)
       words_int_dense = tf.sparse_to_dense(
           words_int_sparse.indices,
@@ -70,7 +73,10 @@ class TextPreprocessor(object):
           words_int_sparse.values,
           default_value=0)
 
-      return tf.squeeze(words_int_dense)
+      if single_record_level:
+        return tf.squeeze(words_int_dense)
+      else:
+        return words_int_dense
 
     return _tokenize_tensor_op
 

--- a/experiments/tf_trainer/common/text_preprocessor.py
+++ b/experiments/tf_trainer/common/text_preprocessor.py
@@ -34,7 +34,7 @@ class TextPreprocessor(object):
         TextPreprocessor._get_word_idx_and_embeddings(
             embeddings_path)  # type: Tuple[Dict[str, int], np.ndarray, int]
 
-  def tokenize_tensor_op_tf_func(self, single_record_level=True) -> Callable[[types.Tensor], types.Tensor]:
+  def tokenize_tensor_op_tf_func(self) -> Callable[[types.Tensor], types.Tensor]:
     """Tensor op that converts some text into an array of ints that correspond
     with this preprocessor's embedding.
 
@@ -54,29 +54,20 @@ class TextPreprocessor(object):
       '''Converts a string Tensor to an array of integers.
 
       Args:
-        text: must be a scalar string tensor (rank 0).
+        text: must be a 1-D Tensor string tensor.
 
       Returns:
-        A 1-D Tensor of word integers.
+        A 2-D Tensor of word integers.
       '''
 
       # TODO: Improve tokenizer.
       # TODO: Ensure utf-8 encoding. Currently the string is parsed with default encoding (unclear). 
-      if single_record_level:
-        words = tf.string_split([text])
-      else:
-        words = tf.string_split(text)
+      words = tf.string_split(text)
       words_int_sparse = vocabulary_table.lookup(words)
-      words_int_dense = tf.sparse_to_dense(
-          words_int_sparse.indices,
-          words_int_sparse.dense_shape,
-          words_int_sparse.values,
+      words_int_dense = tf.sparse_tensor_to_dense(
+          words_int_sparse,
           default_value=0)
-
-      if single_record_level:
-        return tf.squeeze(words_int_dense)
-      else:
-        return words_int_dense
+      return words_int_dense
 
     return _tokenize_tensor_op
 

--- a/experiments/tf_trainer/common/text_preprocessor.py
+++ b/experiments/tf_trainer/common/text_preprocessor.py
@@ -34,7 +34,7 @@ class TextPreprocessor(object):
         TextPreprocessor._get_word_idx_and_embeddings(
             embeddings_path)  # type: Tuple[Dict[str, int], np.ndarray, int]
 
-  def tokenize_tensor_op_tf_func(self, single_record_level=False) -> Callable[[types.Tensor], types.Tensor]:
+  def tokenize_tensor_op_tf_func(self, single_record_level=True) -> Callable[[types.Tensor], types.Tensor]:
     """Tensor op that converts some text into an array of ints that correspond
     with this preprocessor's embedding.
 

--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -87,7 +87,9 @@ class TFRecordInput(dataset_input.DatasetInput):
 
     text = parsed[self._text_feature]
     # I think this could be a feature column, but feature columns seem so beta.
-    preprocessed_text = feature_preprocessor(text)
+    expanded_text = tf.expand_dims(text, 0)
+    preprocessed_text = tf.squeeze(
+        feature_preprocessor(expanded_text))
     features = {self._text_feature: preprocessed_text}
     if self._round_labels:
       labels = {label: tf.round(parsed[label]) for label in self._labels}

--- a/experiments/tf_trainer/keras_gru_attention/run.deploy.sh
+++ b/experiments/tf_trainer/keras_gru_attention/run.deploy.sh
@@ -4,8 +4,7 @@
 # Edit these!
 MODEL_NAME=keras_gru_attention
 # By default, the model is the last one from the user.
-MODEL_SAVED_PATH_FOLDER=$(gsutil ls gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/)
-MODEL_SAVED_PATH=${MODEL_SAVED_PATH_FOLDER}model_dir
+MODEL_SAVED_PATH=$(gsutil ls gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/ | tail -1)
 
 # Create a new model.
 # Will raise an error if the model already exists.
@@ -17,5 +16,4 @@ MODEL_VERSION=v_$(date +"%Y%m%d_%H%M%S")
 gcloud ml-engine versions create $MODEL_VERSION \
   --model $MODEL_NAME \
   --origin $MODEL_SAVED_PATH \
-  --runtime-version 1.8
-
+  --runtime-version 1.8 

--- a/experiments/tf_trainer/keras_gru_attention/run.py
+++ b/experiments/tf_trainer/keras_gru_attention/run.py
@@ -32,7 +32,7 @@ tf.app.flags.DEFINE_boolean("preprocess_in_tf", True,
                            "required for serving.")
 tf.app.flags.DEFINE_integer("batch_size", 64,
                             "The batch size to use during training.")
-tf.app.flags.DEFINE_integer("train_steps", 100,
+tf.app.flags.DEFINE_integer("train_steps", 0,
                             "The number of steps to train for.")
 tf.app.flags.DEFINE_integer("eval_period", 50,
                             "The number of steps per eval period.")
@@ -76,6 +76,7 @@ def main(argv):
   trainer.train_with_eval(FLAGS.train_steps, FLAGS.eval_period, FLAGS.eval_steps)
 
   if FLAGS.preprocess_in_tf:
+    tokenize_op_init = lambda: preprocessor.tokenize_tensor_op_tf_func(single_record_level=False)
     serving_input_fn = serving_input.create_serving_input_fn(
         feature_preprocessor_init=tokenize_op_init,
         text_feature_name=text_feature_name,

--- a/experiments/tf_trainer/keras_gru_attention/run.py
+++ b/experiments/tf_trainer/keras_gru_attention/run.py
@@ -32,7 +32,7 @@ tf.app.flags.DEFINE_boolean("preprocess_in_tf", True,
                            "required for serving.")
 tf.app.flags.DEFINE_integer("batch_size", 64,
                             "The batch size to use during training.")
-tf.app.flags.DEFINE_integer("train_steps", 0,
+tf.app.flags.DEFINE_integer("train_steps", 1000,
                             "The number of steps to train for.")
 tf.app.flags.DEFINE_integer("eval_period", 50,
                             "The number of steps per eval period.")
@@ -76,7 +76,6 @@ def main(argv):
   trainer.train_with_eval(FLAGS.train_steps, FLAGS.eval_period, FLAGS.eval_steps)
 
   if FLAGS.preprocess_in_tf:
-    tokenize_op_init = lambda: preprocessor.tokenize_tensor_op_tf_func(single_record_level=False)
     serving_input_fn = serving_input.create_serving_input_fn(
         feature_preprocessor_init=tokenize_op_init,
         text_feature_name=text_feature_name,


### PR DESCRIPTION
Please review this.

There is one "ugly" workaround. 
The tokenizer is different for training and for serving. Indeed, for training the tokenizer will be used within a map function and then processes one example at a time, whereas for serving the tokenizer needs to process an entire batch.

Therefore, in run.py, I initialize twice the tokenizer. It does not seem a big deal to me but I acknowledge it could be improved. I tried to merge (by doing all per batch or per example) but unsuccessfully.
Might be a TODO or a github issue.

Let me know your thoughts.