### PR TITLE
Fix tfrecord input

### DIFF
--- a/experiments/setup.py
+++ b/experiments/setup.py
@@ -1,8 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-REQUIRED_PACKAGES = ['Keras==2.2.0', 'comet-ml==1.0.16', 'nltk>=3.3',
-                      'typed_ast==1.1.0', 'tensorflow-gpu==1.5']
+REQUIRED_PACKAGES = ['Keras==2.2.0', 'comet-ml==1.0.16', 'nltk>=3.3', 'typed_ast==1.1.0']
 
 setup(
     name='tf_trainer',

--- a/experiments/setup.py
+++ b/experiments/setup.py
@@ -1,7 +1,8 @@
 from setuptools import find_packages
 from setuptools import setup
 
-REQUIRED_PACKAGES = ['Keras==2.2.0', 'comet-ml==1.0.16', 'nltk>=3.3', 'typed_ast==1.1.0']
+REQUIRED_PACKAGES = ['Keras==2.2.0', 'comet-ml==1.0.16', 'nltk>=3.3',
+                      'typed_ast==1.1.0', 'tensorflow-gpu==1.5']
 
 setup(
     name='tf_trainer',

--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -77,11 +77,17 @@ class TFRecordInput(dataset_input.DatasetInput):
     The input TF Example has a text feature as a singleton list with the full
     comment as the single element.
     """
+    DEFAULT_VALUES = {
+      tf.string: '',
+      tf.float32: -1.0,
+      tf.int32: -1
+    }
 
     keys_to_features = {}
     keys_to_features[self._text_feature] = tf.FixedLenFeature([], tf.string)
     for label, dtype in self._labels.items():
-      keys_to_features[label] = tf.FixedLenFeature([], dtype)
+      keys_to_features[label] = tf.FixedLenFeature(
+        [], dtype, DEFAULT_VALUES[dtype])
     parsed = tf.parse_single_example(
         record, keys_to_features)  # type: Dict[str, types.Tensor]
 


### PR DESCRIPTION
Adds a default value to tfrecord_input so that not all labels must be present in every record.
Fixes tfrecord_input_test which had previously been broken (and adds test for default values).