### PR TITLE
Change embedding

### DIFF
--- a/experiments/tf_trainer/keras_gru_attention/run.hyperparameter.sh
+++ b/experiments/tf_trainer/keras_gru_attention/run.hyperparameter.sh
@@ -21,8 +21,8 @@ gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIM
     -- \
     --train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord" \
     --validate_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord" \
-    --embeddings_path="${GCS_RESOURCES}/glove.6B/glove.6B.300d.txt" \
+    --embeddings_path="${GCS_RESOURCES}/google-news/GoogleNews-vectors-negative300.txt" \
     --model_dir="${JOB_DIR}/model_dir" \
     --comet_key_file="${REMOTE_COMET_API_KEY_FILE}" \
     --comet_team_name="jigsaw" \
-    --comet_project_name="experiments${USER}"
+    --comet_project_name="experiments"

--- a/experiments/tf_trainer/keras_gru_attention/run.local.sh
+++ b/experiments/tf_trainer/keras_gru_attention/run.local.sh
@@ -6,5 +6,5 @@ GCS_RESOURCES="gs://kaggle-model-experiments/resources"
 python3 -m tf_trainer.keras_gru_attention.run \
   --train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord" \
   --validate_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord" \
-  --embeddings_path="${GCS_RESOURCES}/glove.6B/glove.6B.100d.txt" \
+  --embeddings_path="${GCS_RESOURCES}/google-news/GoogleNews-vectors-negative300.txt" \
   --model_dir="keras_gru_attention_local_model_dir"

--- a/experiments/tf_trainer/keras_gru_attention/run.ml_engine.sh
+++ b/experiments/tf_trainer/keras_gru_attention/run.ml_engine.sh
@@ -22,7 +22,7 @@ gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIM
     -- \
     --train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord" \
     --validate_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord" \
-    --embeddings_path="${GCS_RESOURCES}/glove.6B/glove.6B.300d.txt" \
+    --embeddings_path="${GCS_RESOURCES}/google-news/GoogleNews-vectors-negative300.txt" \
     --model_dir="${JOB_DIR}/model_dir" \
     --comet_key_file="${REMOTE_COMET_API_KEY_FILE}" \
     --comet_team_name="jigsaw" \

--- a/experiments/tf_trainer/keras_gru_attention/run.py
+++ b/experiments/tf_trainer/keras_gru_attention/run.py
@@ -23,6 +23,8 @@ FLAGS = tf.app.flags.FLAGS
 tf.app.flags.DEFINE_string("embeddings_path",
                            "local_data/glove.6B/glove.6B.100d.txt",
                            "Path to the embeddings file.")
+tf.app.flags.DEFINE_boolean("is_binary_embedding", True,
+                           "Whether embeddings are binaries.")
 tf.app.flags.DEFINE_string("text_feature_name", "comment_text",
                            "Feature name of the text feature.")
 tf.app.flags.DEFINE_string("key_name", "comment_key",
@@ -50,10 +52,11 @@ def main(argv):
   del argv  # unused
 
   embeddings_path = FLAGS.embeddings_path
+  is_binary_embedding = FLAGS.is_binary_embedding
   text_feature_name = FLAGS.text_feature_name
   key_name = FLAGS.key_name
 
-  preprocessor = text_preprocessor.TextPreprocessor(embeddings_path)
+  preprocessor = text_preprocessor.TextPreprocessor(embeddings_path, is_binary_embedding)
   if FLAGS.preprocess_in_tf:
     tokenize_op_init = lambda: preprocessor.tokenize_tensor_op_tf_func()
   else:
@@ -84,4 +87,5 @@ def main(argv):
 
 
 if __name__ == "__main__":
+  tf.logging.set_verbosity(tf.logging.INFO)
   tf.app.run(main)


### PR DESCRIPTION
This commit includes:
- A flag to say if embedding file is 'rb' or 'r'. I tried to extract automatically this from the file but it was trickier than expected: some embeddings can be read 50% with 'r' before throwing an error. That means that, if you want to check the file format and start looking at the wrong one, you will go 1.5 through the embedding size. --> this is very slow. I prefer to trust the user and putting an error message to highlight the parameter to the user.
As default is 'r', this should be compatible with other branches as Glove is 'r'.

- The fix to handle large embeddings.
This should also be compatible with other branches.

Let me know what you think!
