### PR TITLE
Fixing bug input rank

### DIFF
--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -88,8 +88,9 @@ class TFRecordInput(dataset_input.DatasetInput):
     text = parsed[self._text_feature]
     # I think this could be a feature column, but feature columns seem so beta.
     expanded_text = tf.expand_dims(text, 0)
-    preprocessed_text = tf.squeeze(
-        feature_preprocessor(expanded_text))
+    x = feature_preprocessor(expanded_text)
+    # Reshape to (sequence_length,).
+    preprocessed_text = tf.reshape(x, shape=[tf.shape(x)[-1]])
     features = {self._text_feature: preprocessed_text}
     if self._round_labels:
       labels = {label: tf.round(parsed[label]) for label in self._labels}


### PR DESCRIPTION
As mentioned earlier, this should solve the problem of rank for iterator.

This problem happened when there was only 1 word in a sentence. In this case, tf.squeeze would turn the tensor into a scalar.
So, we wanted a sentence of rank 1 (shape = (sequence_length,)), but got a scalar of rank 0.
