### PR TITLE
Enforcing nltk tokenizer

### DIFF
--- a/experiments/tf_trainer/common/serving_input.py
+++ b/experiments/tf_trainer/common/serving_input.py
@@ -7,58 +7,41 @@ from __future__ import print_function
 import tensorflow as tf
 from tensorflow.python.ops import array_ops
 
-FLAGS = tf.app.flags.FLAGS
 
-tf.app.flags.DEFINE_string("serving_format", "TFRECORDS",
-                           "Format of inputs in inference."
-                           "Can be either JSON or TFRECORDS.")
-
-
-def create_serving_input_fn(feature_preprocessor_init, text_feature_name, key_name):
-
-  def serving_input_fn_json():
-    features_placeholders = {}
-    features_placeholders[text_feature_name] = array_ops.placeholder(
-        dtype=tf.string, name=text_feature_name)
-    features_placeholders[key_name] = array_ops.placeholder(
-        dtype=tf.string, name=key_name)
-
-    features = {}
-    features[key_name] = features_placeholders[key_name]
-    feature_preprocessor = feature_preprocessor_init()
-    features[text_feature_name] = feature_preprocessor(
-      features_placeholders[text_feature_name])
-
-    return tf.estimator.export.ServingInputReceiver(
-        features,
-        features_placeholders)
+def create_serving_input_fn(word_to_idx, unknown_token, text_feature_name, key_name):
 
   def serving_input_fn_tfrecords():
+
     serialized_example = tf.placeholder(
         shape=[None],
         dtype=tf.string,
         name="input_example_tensor"
     )
     feature_spec = {
-        text_feature_name: tf.FixedLenFeature([], dtype=tf.string),
+        text_feature_name: tf.VarLenFeature(dtype=tf.string),
         key_name: tf.FixedLenFeature([], dtype=tf.int64)
     }
 
     features = tf.parse_example(
         serialized_example, feature_spec)
-    feature_preprocessor = feature_preprocessor_init()
-    features[text_feature_name] = feature_preprocessor(
-        features[text_feature_name])
+
+    keys = list(word_to_idx.keys())
+    values = list(word_to_idx.values())
+    vocabulary_table = tf.contrib.lookup.HashTable(
+        tf.contrib.lookup.KeyValueTensorInitializer(
+            keys,
+            values,
+            key_dtype=tf.string,
+            value_dtype=tf.int64),
+        unknown_token)
+    words_int_sparse = vocabulary_table.lookup(features[text_feature_name])
+    words_int_dense = tf.sparse_tensor_to_dense(
+        words_int_sparse,
+        default_value=0)
+    features[text_feature_name] = words_int_dense
 
     return tf.estimator.export.ServingInputReceiver(
         features,
         serialized_example)
   
-  if FLAGS.serving_format == 'TFRECORDS':
-    return serving_input_fn_tfrecords
-  elif FLAGS.serving_format == 'JSON':
-    return serving_input_fn_json
-  else:
-    raise ValueError('Serving format not implemented.'
-        ' Should be one of ["JSON", "TFRECORDS"].'
-        )
+  return serving_input_fn_tfrecords

--- a/experiments/tf_trainer/common/text_preprocessor.py
+++ b/experiments/tf_trainer/common/text_preprocessor.py
@@ -22,11 +22,9 @@ class TextPreprocessor(object):
   Takes an embedding and uses it to produce a word to index mapping and an
   embedding matrix.
 
-  NOTE: You might be wondering why we don't go straight from the word to the
-  embedding. The (maybe incorrect) thought process is that
-  the embedding portion can be made a part of the tensorflow graph whereas the
-  word to index portion can not (since words have variable length). Future work
-  may include fixing a max word length.
+  Note: Due to the lack of text preprocessing functions in tensorflow, we expect 
+    that the text is already preprocessed (list of words) in inference.
+    In training, due to the availability of tf.py_func, we handle the preprocessing.
   """
 
   def __init__(self, 
@@ -37,86 +35,45 @@ class TextPreprocessor(object):
         TextPreprocessor._get_word_idx_and_embeddings(
             embeddings_path,
             is_binary_embedding)  # type: Tuple[Dict[str, int], np.ndarray, int]
+  
+  def train_preprocess_fn(self, 
+                         tokenizer: Callable[[str], List[str]],
+                         lowercase: Optional[bool] = True
+                         ) -> Callable[[types.Tensor], types.Tensor]:
 
-  def tokenize_tensor_op_tf_func(self) -> Callable[[types.Tensor], types.Tensor]:
-    """Tensor op that converts some text into an array of ints that correspond
-    with this preprocessor's embedding.
-
-    This function is implemented only with TensorFlow operations and is
-    therefore compatible with TF-Serving (vs. tokenize_tensor_op_py_func).
-    """
-
-    vocabulary_table = tf.contrib.lookup.HashTable(
-        tf.contrib.lookup.KeyValueTensorInitializer(
-            keys=list(self._word_to_idx.keys()),
-            values=list(self._word_to_idx.values()),
-            key_dtype=tf.string,
-            value_dtype=tf.int64),
-        default_value=self._unknown_token)
-
-    def _tokenize_tensor_op(text: types.Tensor) -> types.Tensor:
-      '''Converts a string Tensor to an array of integers.
+    def _tokenize(text: bytes) -> np.ndarray:
+      """Converts text to a list of words.
 
       Args:
-        text: must be a 1-D Tensor string tensor.
+        text: text to tokenize (string).
+        lowercase: whether to include lowercasing in preprocessing (boolean).
+        tokenizer: Python function to tokenize the text on.
 
       Returns:
-        A 2-D Tensor of word integers.
-      '''
+        A list of strings (words).
+      """
 
-      # TODO: Ensure utf-8 encoding. Currently the string is parsed with default encoding (unclear).
-      text = tf.regex_replace(
-          text,
-          '[!"#$%&()*+,-./:;<=>?@[\]^_`{|}~]',
-          ' ')
-      words = tf.string_split(text)
-      words_int_sparse = vocabulary_table.lookup(words)
-      words_int_dense = tf.sparse_tensor_to_dense(
-          words_int_sparse,
-          default_value=0)
-      return words_int_dense
-
-    return _tokenize_tensor_op
-
-  def tokenize_tensor_op_py_func(self, 
-                                tokenizer: Callable[[str], List[str]],
-                                lowercase: Optional[bool] = True
-                                ) -> Callable[[types.Tensor], types.Tensor]:
-    """Tensor op that converts some text into an array of ints that correspond
-    with this preprocessor's embedding.
-
-    This function is implemented with python operations and is therefore
-    incompatible with TF-Serving (vs. tokenize_tensor_op_tf_func_).
-    """
-
-    def _tokenize_tensor_op(text: types.Tensor) -> types.Tensor:
-      '''Converts a string Tensor to an array of integers.
-
-      Args:
-        text: must be a 1-D Tensor string tensor.
-
-      Returns:
-        A 2-D Tensor of word integers.
-      '''
-
-      def _tokenize(sentences: List[bytes]) -> np.ndarray:
-        
-        if len(sentences) > 1:
-          raise ValueError('py_tokenizer does not support padding for now'
-                           ' and can not be run on multiple sentences.')
-
-        sentence = sentences[0]
-        words = tokenizer(sentence.decode('utf-8'))
-        if lowercase:
-          words = [w.lower() for w in words]
-        return np.asarray([[
+      words = tokenizer(text.decode('utf-8'))
+      if lowercase:
+        words = [w.lower() for w in words]
+      return np.asarray([
             self._word_to_idx.get(w, self._unknown_token)
             for w in words
-        ]])
+        ])
 
-      return tf.py_func(_tokenize, [text], tf.int64)
+    def _preprocess_fn(text: types.Tensor) -> types.Tensor:
+      '''Converts a text into a list of integers.
 
-    return _tokenize_tensor_op
+      Args:
+        text: a 0-D string Tensor.
+
+      Returns:
+        A 1-D int64 Tensor.
+      '''
+      words = tf.py_func(_tokenize, [text], tf.int64)
+      return words
+
+    return _preprocess_fn
 
   def add_embedding_to_model(self, model: base_model.BaseModel,
                              text_feature_name: str) -> base_model.BaseModel:
@@ -126,7 +83,6 @@ class TextPreprocessor(object):
       model: An existing BaseModel instance.
       text_feature_name: The name of the feature containing text.
     """
-
     return model.map(
         functools.partial(self.create_estimator_with_embedding,
                           text_feature_name))
@@ -146,7 +102,6 @@ class TextPreprocessor(object):
     Note: We need to consider the case of large embeddings (see: 
       https://stackoverflow.com/questions/48217599/
       how-to-initialize-embeddings-layer-within-estimator-api/48243086#48243086).
-
     """
     old_model_fn = estimator.model_fn
     old_config = estimator.config
@@ -161,8 +116,8 @@ class TextPreprocessor(object):
           estimator_spec.scaffold.init_fn(scaffold, sess)
       
       scaffold = tf.train.Scaffold(
-        init_fn=new_init_fn,
-        copy_from_scaffold=estimator_spec.scaffold)
+          init_fn=new_init_fn,
+          copy_from_scaffold=estimator_spec.scaffold)
       estimator_spec_with_scaffold = tf.estimator.EstimatorSpec(
           mode=estimator_spec.mode,
           predictions=estimator_spec.predictions,
@@ -207,16 +162,6 @@ class TextPreprocessor(object):
 
   def unknown_token(self) -> int:
     return self._unknown_token
-
-  def word_to_idx_table(self) -> tf.contrib.lookup.HashTable:
-    """Get word to index mapping as a TF HashTable."""
-
-    keys = list(self._word_to_idx.keys())
-    values = list(self._word_to_idx.values())
-    table = tf.contrib.lookup.HashTable(
-        tf.contrib.lookup.KeyValueTensorInitializer(keys, values),
-        self._unknown_token)
-    return table
 
   def word_embeddings(self, trainable=True) -> tf.Variable:
     """Get word embedding TF Variable."""

--- a/experiments/tf_trainer/keras_gru_attention/run.py
+++ b/experiments/tf_trainer/keras_gru_attention/run.py
@@ -29,12 +29,9 @@ tf.app.flags.DEFINE_string("text_feature_name", "comment_text",
                            "Feature name of the text feature.")
 tf.app.flags.DEFINE_string("key_name", "comment_key",
                            "Name of the key feature for serving examples.")
-tf.app.flags.DEFINE_boolean("preprocess_in_tf", False,
-                           "Run preprocessing with TensorFlow operations,"
-                           "required for serving.")
-tf.app.flags.DEFINE_integer("batch_size", 64,
+tf.app.flags.DEFINE_integer("batch_size", 32,
                             "The batch size to use during training.")
-tf.app.flags.DEFINE_integer("train_steps", 20000,
+tf.app.flags.DEFINE_integer("train_steps", 10000,
                             "The number of steps to train for.")
 tf.app.flags.DEFINE_integer("eval_period", 100,
                             "The number of steps per eval period.")
@@ -58,18 +55,15 @@ def main(argv):
   key_name = FLAGS.key_name
 
   preprocessor = text_preprocessor.TextPreprocessor(embeddings_path, is_binary_embedding)
-  if FLAGS.preprocess_in_tf:
-    tokenize_op_init = lambda: preprocessor.tokenize_tensor_op_tf_func()
-  else:
-    nltk.download("punkt")
-    tokenize_op_init = lambda: preprocessor.tokenize_tensor_op_py_func(nltk.word_tokenize)
 
+  nltk.download("punkt")
+  train_preprocess_fn = preprocessor.train_preprocess_fn(nltk.word_tokenize)
   dataset = tfrecord_input.TFRecordInput(
       train_path=FLAGS.train_path,
       validate_path=FLAGS.validate_path,
       text_feature=text_feature_name,
       labels=LABELS,
-      feature_preprocessor_init=tokenize_op_init,
+      train_preprocess_fn=train_preprocess_fn,
       batch_size=FLAGS.batch_size)
 
   # TODO: Move embedding *into* Keras model.
@@ -82,12 +76,12 @@ def main(argv):
   trainer = model_trainer.ModelTrainer(dataset, model)
   trainer.train_with_eval(FLAGS.train_steps, FLAGS.eval_period, FLAGS.eval_steps)
 
-  if FLAGS.preprocess_in_tf:
-    serving_input_fn = serving_input.create_serving_input_fn(
-        feature_preprocessor_init=tokenize_op_init,
-        text_feature_name=text_feature_name,
-        key_name=key_name)
-    trainer.export(serving_input_fn)
+  serving_input_fn = serving_input.create_serving_input_fn(
+      word_to_idx=preprocessor._word_to_idx,
+      unknown_token=preprocessor._unknown_token,
+      text_feature_name=text_feature_name,
+      key_name=key_name)
+  trainer.export(serving_input_fn)
 
 
 if __name__ == "__main__":

--- a/experiments/tf_trainer/tf_gru_attention/run.py
+++ b/experiments/tf_trainer/tf_gru_attention/run.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 from tf_trainer.common import model_trainer
 
 from tf_trainer.common import tfrecord_input
+from tf_trainer.common import serving_input
 from tf_trainer.common import text_preprocessor
 from tf_trainer.common import types
 from tf_trainer.tf_gru_attention import model as tf_gru_attention
@@ -28,12 +29,9 @@ tf.app.flags.DEFINE_string("text_feature_name", "comment_text",
                            "Feature name of the text feature.")
 tf.app.flags.DEFINE_string("key_name", "comment_key",
                            "Name of the key feature for serving examples.")
-tf.app.flags.DEFINE_boolean("preprocess_in_tf", False,
-                           "Run preprocessing with TensorFlow operations,"
-                           "required for serving.")
-tf.app.flags.DEFINE_integer("batch_size", 64,
+tf.app.flags.DEFINE_integer("batch_size", 32,
                             "The batch size to use during training.")
-tf.app.flags.DEFINE_integer("train_steps", 1000,
+tf.app.flags.DEFINE_integer("train_steps", 100,
                             "The number of steps to train for.")
 tf.app.flags.DEFINE_integer("eval_period", 50,
                             "The number of steps per eval period.")
@@ -55,19 +53,22 @@ def main(argv):
   text_feature_name = FLAGS.text_feature_name
   key_name = FLAGS.key_name
 
-  preprocessor = text_preprocessor.TextPreprocessor(embeddings_path, is_binary_embedding)
-  if FLAGS.preprocess_in_tf:
-    tokenize_op_init = lambda: preprocessor.tokenize_tensor_op_tf_func()
-  else:
-    nltk.download("punkt")
-    tokenize_op_init = lambda: preprocessor.tokenize_tensor_op_py_func(nltk.word_tokenize)
+  
+  embeddings_path = FLAGS.embeddings_path
+  is_binary_embedding = FLAGS.is_binary_embedding
+  text_feature_name = FLAGS.text_feature_name
+  key_name = FLAGS.key_name
 
+  preprocessor = text_preprocessor.TextPreprocessor(embeddings_path, is_binary_embedding)
+
+  nltk.download("punkt")
+  train_preprocess_fn = preprocessor.train_preprocess_fn(nltk.word_tokenize)
   dataset = tfrecord_input.TFRecordInput(
       train_path=FLAGS.train_path,
       validate_path=FLAGS.validate_path,
       text_feature=text_feature_name,
       labels=LABELS,
-      feature_preprocessor_init=tokenize_op_init,
+      train_preprocess_fn=train_preprocess_fn,
       batch_size=FLAGS.batch_size)
 
   # TODO: Move embedding *into* Keras model.
@@ -81,12 +82,8 @@ def main(argv):
   trainer = model_trainer.ModelTrainer(dataset, model)
   trainer.train_with_eval(FLAGS.train_steps, FLAGS.eval_period, FLAGS.eval_steps)
 
-  if FLAGS.preprocess_in_tf:
-    serving_input_fn = serving_input.create_serving_input_fn(
-        feature_preprocessor_init=tokenize_op_init,
-        text_feature_name=text_feature_name,
-        key_name=key_name)
-    trainer.export(serving_input_fn)
+  # TODO: Add serving function for TF model.
+
 
 if __name__ == "__main__":
   tf.logging.set_verbosity(tf.logging.INFO)

--- a/model_evaluation/jigsaw_evaluation_pipeline.ipynb
+++ b/model_evaluation/jigsaw_evaluation_pipeline.ipynb
@@ -153,6 +153,7 @@
     "\n",
     "import getpass\n",
     "import json\n",
+    "import nltk\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import pkg_resources\n",
@@ -233,6 +234,45 @@
     "Cleaned datasets must be pandas DataFrames and must include the following fields:\n",
     "- `text`: the raw text string of the comment.\n",
     "- `label`: label associated to this comment. Must be True for toxic."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define tokenizer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Due to the lack of text preprocessing functions in tensorflow, we expect that the text is already preprocessed (list of words) in inference.\n",
+    "\n",
+    "In training, due to the availability of tf.py_func, we handle the preprocessing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tokenizer(text, lowercase=True):\n",
+    "  \"\"\"Converts text to a list of words.\n",
+    "\n",
+    "  Args:\n",
+    "    text: text to tokenize (string).\n",
+    "    lowercase: whether to include lowercasing in preprocessing (boolean).\n",
+    "    tokenizer: Python function to tokenize the text on.\n",
+    "\n",
+    "  Returns:\n",
+    "    A list of strings (words).\n",
+    "  \"\"\"\n",
+    "  words = nltk.word_tokenize(text.decode('utf-8'))\n",
+    "  if lowercase:\n",
+    "    words = [w.lower() for w in words]\n",
+    "  return words"
    ]
   },
   {
@@ -376,10 +416,20 @@
     "# Setting the table to match the required format.\n",
     "test_performance_df = test_performance_df.rename(\n",
     "    columns={\n",
-    "        TEXT_FEATURE_NAME: 'text',\n",
+    "        TEXT_FEATURE_NAME: 'raw_text',\n",
     "        LABEL_NAME: 'label'\n",
     "    })\n",
     "test_performance_df['label'] = list(map(lambda x :bool(round(x)), list(test_performance_df['label'])))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add preprocessing\n",
+    "test_performance_df['text'] = list(map(tokenizer, test_performance_df['raw_text']))"
    ]
   },
   {
@@ -453,13 +503,23 @@
     "# Loading it from it the unintended_ml_bias github.\n",
     "test_bias_df = pd.read_csv(\n",
     "    pkg_resources.resource_stream(\"unintended_ml_bias\", \"eval_datasets/bias_madlibs_77k.csv\"))\n",
-    "test_bias_df['text'] = test_bias_df['Text']\n",
+    "test_bias_df['raw_text'] = test_bias_df['Text']\n",
     "test_bias_df['label'] = test_bias_df['Label']\n",
     "test_bias_df['label'] = list(map(lambda x: x=='BAD', test_bias_df['label']))\n",
-    "test_bias_df = test_bias_df[['text', 'label']].copy()\n",
+    "test_bias_df = test_bias_df[['raw_text', 'label']].copy()\n",
     "terms = [line.strip()\n",
     "         for line in pkg_resources.resource_stream(\"unintended_ml_bias\", \"bias_madlibs_data/adjectives_people.txt\")]\n",
-    "model_bias_analysis.add_subgroup_columns_from_text(test_bias_df, 'text', terms)"
+    "model_bias_analysis.add_subgroup_columns_from_text(test_bias_df, 'raw_text', terms)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add preprocessing\n",
+    "test_bias_df['text'] = list(map(tokenizer, test_bias_df['raw_text']))"
    ]
   },
   {
@@ -528,7 +588,7 @@
    "source": [
     "# User inputs.\n",
     "MODEL_FAMILIES = [\n",
-    "    ['keras_gru_attention:v_20180717_100612']\n",
+    "    ['keras_gru_attention:v_20180817_093854']\n",
     "    ]"
    ]
   },
@@ -570,6 +630,9 @@
     "def _int64_feature(value):\n",
     "  return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))\n",
     "\n",
+    "def _bytes__list_feature(value_list):\n",
+    "  return tf.train.Feature(\n",
+    "      bytes_list=tf.train.BytesList(value=[tf.compat.as_bytes(value) for value in value_list]))\n",
     "\n",
     "def _write_pandas_to_tf_records(df, gcs_path):\n",
     "  '''Write a pandas `DataFrame` to a tf_record.\n",
@@ -588,7 +651,7 @@
     "          print ('Preparing train data: {}/{}'.format(i, len(df)))\n",
     "      \n",
     "      # Create a feature\n",
-    "      feature = {TEXT_FEATURE_NAME: _bytes_feature(tf.compat.as_bytes(df['text'].iloc[i])),\n",
+    "      feature = {TEXT_FEATURE_NAME: _bytes__list_feature(df['text'].iloc[i]),\n",
     "                 SENTENCE_KEY: _int64_feature(i)}\n",
     "      example = tf.train.Example(features=tf.train.Features(feature=feature))\n",
     "\n",
@@ -736,8 +799,8 @@
     "    response = request.execute()\n",
     "    job_completed = (response['state'] == 'SUCCEEDED')\n",
     "    if not (k % 5) and not job_completed:\n",
-    "      print ('Waiting for prediction job to complete. Min elapsed: {}'.format(0.5*k))\n",
-    "      time.sleep(30)\n",
+    "      print ('Waiting for prediction job to complete. Minutes elapsed: {}'.format(0.5*k))\n",
+    "    time.sleep(30)\n",
     "  \n",
     "  print ('Prediction job completed.')\n",
     "\n",
@@ -889,12 +952,12 @@
     "TF_RECORD_BIAS_INPUT = os.path.join(\n",
     "    GCS_BUCKET,\n",
     "    getpass.getuser(),\n",
-    "    'test_bias.tfrecords'\n",
+    "    'tfrecords/test_bias.tfrecords'\n",
     ")\n",
     "TF_RECORD_BIAS_PREDICTION_PREFIX = os.path.join(\n",
     "    GCS_BUCKET,\n",
     "    getpass.getuser(),\n",
-    "    'test_bias_with_predictions_'\n",
+    "    'tfrecords/test_bias_with_predictions_'\n",
     ")"
    ]
   },
@@ -950,7 +1013,7 @@
     "        job_id,\n",
     "        test_performance_df,\n",
     "        project_name=PROJECT_NAME,\n",
-    "        tmp_tfrecords_with_predictions_gcs_path=TF_RECORD_BIAS_PREDICTION_PREFIX + model_full_name,\n",
+    "        tmp_tfrecords_with_predictions_gcs_path=TF_RECORD_PERFORMANCE_PREDICTION_PREFIX + model_full_name,\n",
     "        column_name_of_model=model_full_name\n",
     "    )\n",
     "        \n",
@@ -1285,6 +1348,13 @@
     "      name + ' Pinned AUC',\n",
     "      y_lim=(0., 1.0))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This review does:
- Set as only option a python tokenizer for training
- Change the serving function to expect a list of words.
- Change the evaluation notebook accordingly.

Tests run:
- Training of keras model on Glove + Evaluation in the notebook
- Training of tf_model (serving function for tf left as a todo).

This pr included many changes. Please let me know if new design makes sense! 