### PR TITLE
Serving for tf

### DIFF
--- a/experiments/tf_trainer/common/model_trainer.py
+++ b/experiments/tf_trainer/common/model_trainer.py
@@ -193,8 +193,7 @@ class ModelTrainer(object):
       experiment = self._setup_comet()
     num_itr = int(steps / eval_period)
 
-    writer = tf.summary.FileWriter(self._model_dir())
-    for i in range(num_itr):
+    for _ in range(num_itr):
       hooks = None
       if FLAGS.enable_profiling:
         hooks = [tf.train.ProfilerHook(save_steps=10,

--- a/experiments/tf_trainer/common/model_trainer.py
+++ b/experiments/tf_trainer/common/model_trainer.py
@@ -54,7 +54,7 @@ tf.app.flags.mark_flag_as_required('model_dir')
 # This function extends tf.contrib.estimator.forward_features.
 # As the binary_head has a ClassificationOutput for serving_default,
 # the check at the end of 'new_model_fn' fails in the initial fn.
-def forward_features(estimator, keys=None, sparse_default_values=None):
+def forward_features(estimator, keys, sparse_default_values=None):
   """Forward features to predictions dictionary.
   In some cases, user wants to see some of the features in estimators prediction
   output. As an example, consider a batch prediction service: The service simply
@@ -75,10 +75,7 @@ def forward_features(estimator, keys=None, sparse_default_values=None):
   ```
   Args:
     estimator: A `tf.estimator.Estimator` object.
-    keys: A `string` or a `list` of `string`. If it is `None`, all of the
-      `features` in `dict` is forwarded to the `predictions`. If it is a
-      `string`, only given key is forwarded. If it is a `list` of strings, all
-      the given `keys` are forwarded.
+    keys: A `string`
     sparse_default_values: A dict of `str` keys mapping the name of the sparse
       features to be converted to dense, to the default value to use. Only
       sparse features indicated in the dictionary are converted to dense and the
@@ -156,7 +153,7 @@ def forward_features(estimator, keys=None, sparse_default_values=None):
     spec = spec._replace(predictions=predictions)
     if spec.export_outputs: # CHANGES HERE
       outputs = spec.export_outputs['predict'].outputs
-      outputs['comment_key'] = spec.predictions['comment_key']
+      outputs[key] = spec.predictions[key]
       spec.export_outputs['predict'] = tf.estimator.export.PredictOutput(outputs)
       spec.export_outputs['serving_default'] = tf.estimator.export.PredictOutput(outputs)
     return spec

--- a/experiments/tf_trainer/common/model_trainer.py
+++ b/experiments/tf_trainer/common/model_trainer.py
@@ -41,6 +41,151 @@ tf.app.flags.mark_flag_as_required('validate_path')
 tf.app.flags.mark_flag_as_required('model_dir')
 
 
+
+
+
+
+import six
+
+from tensorflow.python.estimator import estimator as estimator_lib
+from tensorflow.python.estimator import model_fn as model_fn_lib
+from tensorflow.python.estimator.export.export_output import PredictOutput
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import sparse_tensor as sparse_tensor_lib
+from tensorflow.python.ops import clip_ops
+from tensorflow.python.ops import sparse_ops
+from tensorflow.python.training import optimizer as optimizer_lib
+
+
+
+
+def forward_featuresFPROST(estimator, keys=None, sparse_default_values=None):
+  """Forward features to predictions dictionary.
+  In some cases, user wants to see some of the features in estimators prediction
+  output. As an example, consider a batch prediction service: The service simply
+  runs inference on the users graph and returns the results. Keys are essential
+  because there is no order guarantee on the outputs so they need to be rejoined
+  to the inputs via keys or transclusion of the inputs in the outputs.
+  Example:
+  ```python
+    def input_fn():
+      features, labels = ...
+      features['unique_example_id'] = ...
+      features, labels
+    estimator = tf.estimator.LinearClassifier(...)
+    estimator = tf.contrib.estimator.forward_features(
+        estimator, 'unique_example_id')
+    estimator.train(...)
+    assert 'unique_example_id' in estimator.predict(...)
+  ```
+  Args:
+    estimator: A `tf.estimator.Estimator` object.
+    keys: A `string` or a `list` of `string`. If it is `None`, all of the
+      `features` in `dict` is forwarded to the `predictions`. If it is a
+      `string`, only given key is forwarded. If it is a `list` of strings, all
+      the given `keys` are forwarded.
+    sparse_default_values: A dict of `str` keys mapping the name of the sparse
+      features to be converted to dense, to the default value to use. Only
+      sparse features indicated in the dictionary are converted to dense and the
+      provided default value is used.
+  Returns:
+      A new `tf.estimator.Estimator` which forwards features to predictions.
+  Raises:
+    ValueError:
+      * if `keys` is already part of `predictions`. We don't allow
+        override.
+      * if 'keys' does not exist in `features`.
+    TypeError: if `keys` type is not one of `string` or list/tuple of `string`.
+  """
+
+  def verify_key_types(keys):  # pylint: disable=missing-docstring
+    if keys is None:
+      return keys
+    if isinstance(keys, six.string_types):
+      return [keys]
+    if not isinstance(keys, (list, tuple)):
+      raise TypeError('keys should be either a string or a list of strings. '
+                      'Given: {}'.format(type(keys)))
+    for key in keys:
+      if not isinstance(key, six.string_types):
+        raise TypeError('All items in the given keys list should be a string. '
+                        'There exist an item with type: {}'.format(type(key)))
+    return keys
+
+  def get_keys(features):
+    if keys is None:
+      return features.keys()
+    return keys
+
+  def verify_keys_and_predictions(features, predictions):
+    if not isinstance(predictions, dict):
+      raise ValueError(
+          'Predictions should be a dict to be able to forward features. '
+          'Given: {}'.format(type(predictions)))
+    for key in get_keys(features):
+      if key not in features:
+        raise ValueError(
+            'keys should be exist in features. Key "{}" is not in features '
+            'dict. features dict has following keys: {}. Please check '
+            'arguments of forward_features.'.format(key, features.keys()))
+      if key in predictions:
+        raise ValueError(
+            'Cannot forward feature key ({}). Since it does exist in '
+            'predictions. Existing prediction keys: {}. Please check arguments '
+            'of forward_features.'.format(key, predictions.keys()))
+
+  keys = verify_key_types(keys)
+
+  def new_model_fn(features, labels, mode, config):  # pylint: disable=missing-docstring
+    spec = estimator.model_fn(features, labels, mode, config)
+    predictions = spec.predictions
+    if predictions is None:
+      return spec
+    verify_keys_and_predictions(features, predictions)
+    for key in get_keys(features):
+      feature = sparse_tensor_lib.convert_to_tensor_or_sparse_tensor(
+          features[key])
+      if sparse_default_values and (key in sparse_default_values):
+        if not isinstance(feature, sparse_tensor_lib.SparseTensor):
+          raise ValueError(
+              'Feature ({}) is expected to be a `SparseTensor`.'.format(key))
+        feature = sparse_ops.sparse_tensor_to_dense(
+            feature, default_value=sparse_default_values[key])
+      if not isinstance(feature, ops.Tensor):
+        raise ValueError(
+            'Feature ({}) should be a Tensor. Please use `keys` '
+            'argument of forward_features to filter unwanted features, or'
+            'add key to argument `sparse_default_values`.'
+            'Type of features[{}] is {}.'.format(key, key, type(feature)))
+      predictions[key] = feature
+    spec = spec._replace(predictions=predictions)
+    print ('EXPORT_OUTPUTS')
+    print (spec.export_outputs)
+    if spec.export_outputs:
+      for ekey in ['predict', 'serving_default']:
+        print('ekey: ' + ekey)
+        print('t1: ' + str(ekey in spec.export_outputs))
+        print('t2: ' + str(isinstance(spec.export_outputs[ekey], PredictOutput)))
+        print ('export_output: ')
+        print (spec.export_outputs[ekey])
+        # if (ekey in spec.export_outputs and
+        #     isinstance(spec.export_outputs[ekey],
+        #                PredictOutput)):
+        if (ekey in spec.export_outputs):
+          export_outputs = spec.export_outputs[ekey].outputs
+          for key in get_keys(features):
+            print ('key: '+ key)
+            export_outputs[key] = predictions[key]
+
+    return spec
+
+  return estimator_lib.Estimator(
+      model_fn=new_model_fn,
+      model_dir=estimator.model_dir,
+      config=estimator.config)
+
+
+
 def forward_key_to_export(estimator):
   """Forwards record key to output during inference.
 
@@ -61,10 +206,17 @@ def forward_key_to_export(estimator):
   def model_fn2(features, labels, mode):
     estimator_spec = estimator._call_model_fn(
         features, labels, mode, config=config)
-    if estimator_spec.export_outputs:
-      for ekey in ['predict', 'serving_default']:
-        estimator_spec.export_outputs[ekey] = \
-            tf.estimator.export.PredictOutput(estimator_spec.predictions)
+    import six
+    from tensorflow.python.estimator.canned import head as head_lib
+    from tensorflow.python.estimator.canned import metric_keys
+    from tensorflow.python.estimator.export import export_output as export_output_lib
+
+    if mode==tf.estimator.ModeKeys.PREDICT:
+      if estimator_spec.export_outputs:
+        outputs = estimator_spec.export_outputs['predict'].outputs
+        outputs['comment_key'] = estimator_spec.predictions['comment_key']
+        estimator_spec.export_outputs['predict'] = tf.estimator.export.PredictOutput(outputs)
+        estimator_spec.export_outputs['serving_default'] = tf.estimator.export.PredictOutput(outputs)
     return estimator_spec
   return tf.estimator.Estimator(model_fn=model_fn2, config=config)
 
@@ -95,7 +247,8 @@ class ModelTrainer(object):
       experiment = self._setup_comet()
     num_itr = int(steps / eval_period)
 
-    for _ in range(num_itr):
+    writer = tf.summary.FileWriter(self._model_dir())
+    for i in range(num_itr):
       hooks = None
       if FLAGS.enable_profiling:
         hooks = [tf.train.ProfilerHook(save_steps=10,
@@ -109,6 +262,15 @@ class ModelTrainer(object):
       if experiment is not None:
         tf.logging.info('Logging metrics to comet.ml: {}'.format(metrics))
         experiment.log_multiple_metrics(metrics)
+      predictions = self._estimator.predict(self._dataset.bias_input_fn)
+      proba_list = []
+      import numpy as np
+      for prediction in predictions:
+        proba_toxic = prediction[('frac_neg', 'probabilities')][1]
+        proba_list.append(proba_toxic)
+      summary = tf.Summary(value=[tf.Summary.Value(tag='unintended_bias',
+                                                   simple_value=np.mean(proba_list))])
+      writer.add_summary(summary, i * eval_period)
       tf.logging.info(metrics)
 
   def _setup_comet(self):
@@ -140,8 +302,8 @@ class ModelTrainer(object):
 
   def _add_estimator_key(self, estimator):
     '''Adds a forward key to the model_fn of an estimator.'''
-    estimator = tf.contrib.estimator.forward_features(estimator, FLAGS.key_name)
-    estimator = forward_key_to_export(estimator)
+    estimator = forward_featuresFPROST(estimator, FLAGS.key_name) #tf.contrib.estimator.forward_features(estimator, FLAGS.key_name)
+    # estimator = forward_key_to_export(estimator)
     return estimator
 
   def export(self, serving_input_fn):

--- a/experiments/tf_trainer/common/text_preprocessor.py
+++ b/experiments/tf_trainer/common/text_preprocessor.py
@@ -182,7 +182,7 @@ class TextPreprocessor(object):
   @staticmethod
   def _get_word_idx_and_embeddings(embeddings_path: str,
                                    is_binary_embedding: bool,
-                                   max_words: Optional[int] = 100
+                                   max_words: Optional[int] = None
                                   ) -> Tuple[Dict[str, int], np.ndarray, int]:
     """Generate word to idx mapping and word embeddings numpy array.
 

--- a/experiments/tf_trainer/common/text_preprocessor.py
+++ b/experiments/tf_trainer/common/text_preprocessor.py
@@ -15,6 +15,8 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 FLAGS = flags.FLAGS
 
+tf.app.flags.DEFINE_bool('is_embedding_trainable', False,
+                         'Enable fine tuning of embeddings.')
 
 class TextPreprocessor(object):
   """Text Preprocessor.
@@ -136,7 +138,8 @@ class TextPreprocessor(object):
     def new_model_fn(features, labels, mode, params, config):
       """model_fn used in defining the new TF Estimator"""
 
-      embeddings, embedding_init_fn = self.word_embeddings()
+      embeddings, embedding_init_fn = self.word_embeddings(
+          trainable=FLAGS.is_embedding_trainable)
 
       text_feature = features[text_feature_name]
       word_embeddings = tf.nn.embedding_lookup(embeddings, text_feature)
@@ -163,7 +166,7 @@ class TextPreprocessor(object):
   def unknown_token(self) -> int:
     return self._unknown_token
 
-  def word_embeddings(self, trainable=True) -> tf.Variable:
+  def word_embeddings(self, trainable) -> tf.Variable:
     """Get word embedding TF Variable."""
 
     embeddings = tf.get_variable(
@@ -179,7 +182,7 @@ class TextPreprocessor(object):
   @staticmethod
   def _get_word_idx_and_embeddings(embeddings_path: str,
                                    is_binary_embedding: bool,
-                                   max_words: Optional[int] = None
+                                   max_words: Optional[int] = 100
                                   ) -> Tuple[Dict[str, int], np.ndarray, int]:
     """Generate word to idx mapping and word embeddings numpy array.
 

--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -45,16 +45,9 @@ class TFRecordInput(dataset_input.DatasetInput):
     """input_fn for TF Estimators for validation set."""
     return self._input_fn_from_file(self._validate_path)
 
-  def bias_input_fn(self) -> types.FeatureAndLabelTensors:
-    """input_fn for TF Estimators for training set."""
-    return self._input_fn_from_file(
-        self._train_path,
-        max_n_examples=20)
-
   def _input_fn_from_file(
       self,
-      filepath: str,
-      max_n_examples: int = None) -> types.FeatureAndLabelTensors:
+      filepath: str) -> types.FeatureAndLabelTensors:
     dataset = tf.data.TFRecordDataset(filepath)  # type: tf.data.TFRecordDataset
 
     parsed_dataset = dataset.map(
@@ -73,8 +66,6 @@ class TFRecordInput(dataset_input.DatasetInput):
             bucket_batch_sizes=[self._batch_size] * 11,
             padded_shapes=padded_shapes)
         )
-    if max_n_examples:
-      parsed_dataset = parsed_dataset.take(max_n_examples)
     batched_dataset = parsed_dataset.prefetch(self._num_prefetch)
 
     itr_op = batched_dataset.make_initializable_iterator()

--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -45,9 +45,7 @@ class TFRecordInput(dataset_input.DatasetInput):
     """input_fn for TF Estimators for validation set."""
     return self._input_fn_from_file(self._validate_path)
 
-  def _input_fn_from_file(
-      self,
-      filepath: str) -> types.FeatureAndLabelTensors:
+  def _input_fn_from_file(self, filepath: str) -> types.FeatureAndLabelTensors:
     dataset = tf.data.TFRecordDataset(filepath)  # type: tf.data.TFRecordDataset
 
     parsed_dataset = dataset.map(

--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -45,7 +45,16 @@ class TFRecordInput(dataset_input.DatasetInput):
     """input_fn for TF Estimators for validation set."""
     return self._input_fn_from_file(self._validate_path)
 
-  def _input_fn_from_file(self, filepath: str) -> types.FeatureAndLabelTensors:
+  def bias_input_fn(self) -> types.FeatureAndLabelTensors:
+    """input_fn for TF Estimators for training set."""
+    return self._input_fn_from_file(
+        self._train_path,
+        max_n_examples=20)
+
+  def _input_fn_from_file(
+      self,
+      filepath: str,
+      max_n_examples: int = None) -> types.FeatureAndLabelTensors:
     dataset = tf.data.TFRecordDataset(filepath)  # type: tf.data.TFRecordDataset
 
     parsed_dataset = dataset.map(
@@ -64,6 +73,8 @@ class TFRecordInput(dataset_input.DatasetInput):
             bucket_batch_sizes=[self._batch_size] * 11,
             padded_shapes=padded_shapes)
         )
+    if max_n_examples:
+      parsed_dataset = parsed_dataset.take(max_n_examples)
     batched_dataset = parsed_dataset.prefetch(self._num_prefetch)
 
     itr_op = batched_dataset.make_initializable_iterator()

--- a/experiments/tf_trainer/tf_gru_attention/run.py
+++ b/experiments/tf_trainer/tf_gru_attention/run.py
@@ -31,9 +31,9 @@ tf.app.flags.DEFINE_string("key_name", "comment_key",
                            "Name of the key feature for serving examples.")
 tf.app.flags.DEFINE_integer("batch_size", 32,
                             "The batch size to use during training.")
-tf.app.flags.DEFINE_integer("train_steps", 100,
+tf.app.flags.DEFINE_integer("train_steps", 10000,
                             "The number of steps to train for.")
-tf.app.flags.DEFINE_integer("eval_period", 50,
+tf.app.flags.DEFINE_integer("eval_period", 100,
                             "The number of steps per eval period.")
 tf.app.flags.DEFINE_integer("eval_steps", 20,
                             "The number of steps to eval for.")
@@ -53,7 +53,6 @@ def main(argv):
   text_feature_name = FLAGS.text_feature_name
   key_name = FLAGS.key_name
 
-  
   embeddings_path = FLAGS.embeddings_path
   is_binary_embedding = FLAGS.is_binary_embedding
   text_feature_name = FLAGS.text_feature_name
@@ -82,7 +81,12 @@ def main(argv):
   trainer = model_trainer.ModelTrainer(dataset, model)
   trainer.train_with_eval(FLAGS.train_steps, FLAGS.eval_period, FLAGS.eval_steps)
 
-  # TODO: Add serving function for TF model.
+  serving_input_fn = serving_input.create_serving_input_fn(
+      word_to_idx=preprocessor._word_to_idx,
+      unknown_token=preprocessor._unknown_token,
+      text_feature_name=text_feature_name,
+      key_name=key_name)
+  trainer.export(serving_input_fn)
 
 
 if __name__ == "__main__":

--- a/model_evaluation/jigsaw_evaluation_pipeline.ipynb
+++ b/model_evaluation/jigsaw_evaluation_pipeline.ipynb
@@ -306,7 +306,9 @@
     "\n",
     "TEXT_FEATURE_NAME = 'comment_text'\n",
     "SENTENCE_KEY = 'comment_key'\n",
-    "LABEL_NAME = 'frac_neg'"
+    "LABEL_NAME = 'frac_neg'\n",
+    "\n",
+    "PREDICTION_LOGITS_KEY = LABEL_NAME + '/logistic' # key of the logits in the JSON returned by Cloud ML Engine."
    ]
   },
   {
@@ -588,7 +590,8 @@
    "source": [
     "# User inputs.\n",
     "MODEL_FAMILIES = [\n",
-    "    ['keras_gru_attention:v_20180817_093854']\n",
+    "    #['keras_gru_attention:v_20180817_093854']\n",
+    "    ['tf_gru_attention:v_20180823_133625']\n",
     "    ]"
    ]
   },
@@ -805,7 +808,7 @@
     "  print ('Prediction job completed.')\n",
     "\n",
     "    \n",
-    "def _combine_prediction_to_df(df, prediction_file, model_col_name):\n",
+    "def _combine_prediction_to_df(df, prediction_file, model_col_name, prediction_name):\n",
     "  '''Loads the prediction files and adds them to the DataFrame.'''\n",
     "  \n",
     "  def load_predictions(prediction_file):\n",
@@ -820,7 +823,7 @@
     "  if len(predictions) != len(df):\n",
     "    raise ValueError('The dataframe and the prediction file do not contain the same number of lines.')\n",
     "  \n",
-    "  prediction_proba = [x[LABEL_NAME][0] for x in predictions]\n",
+    "  prediction_proba = [x[prediction_name][0] for x in predictions]\n",
     "  \n",
     "  df[model_col_name] = prediction_proba\n",
     "  \n",
@@ -895,7 +898,8 @@
     "\n",
     "\n",
     "def add_model_predictions_to_df(job_id, df, project_name,\n",
-    "                                tmp_tfrecords_with_predictions_gcs_path, column_name_of_model):\n",
+    "                                tmp_tfrecords_with_predictions_gcs_path, column_name_of_model,\n",
+    "                                prediction_name):\n",
     "  '''Adds prediction results to the pandas dataframe.\n",
     "  \n",
     "  Args:\n",
@@ -916,7 +920,7 @@
     "  \n",
     "  # Add one prediction column to the database.\n",
     "  tf_records_path = os.path.join(tmp_tfrecords_with_predictions_gcs_path, 'prediction.results-00000-of-00001')\n",
-    "  df_with_predictions = _combine_prediction_to_df(df, tf_records_path, column_name_of_model)\n",
+    "  df_with_predictions = _combine_prediction_to_df(df, tf_records_path, column_name_of_model, prediction_name)\n",
     "  \n",
     "  return df_with_predictions"
    ]
@@ -1014,7 +1018,8 @@
     "        test_performance_df,\n",
     "        project_name=PROJECT_NAME,\n",
     "        tmp_tfrecords_with_predictions_gcs_path=TF_RECORD_PERFORMANCE_PREDICTION_PREFIX + model_full_name,\n",
-    "        column_name_of_model=model_full_name\n",
+    "        column_name_of_model=model_full_name,\n",
+    "        prediction_name=PREDICTION_LOGITS_KEY\n",
     "    )\n",
     "        \n",
     "    job_id = job_ids_bias[i]\n",
@@ -1023,7 +1028,8 @@
     "        test_bias_df,\n",
     "        project_name=PROJECT_NAME,\n",
     "        tmp_tfrecords_with_predictions_gcs_path=TF_RECORD_BIAS_PREDICTION_PREFIX + model_full_name,\n",
-    "        column_name_of_model=model_full_name\n",
+    "        column_name_of_model=model_full_name,\n",
+    "        prediction_name=PREDICTION_LOGITS_KEY\n",
     "    )\n",
     "    i += 1"
    ]


### PR DESCRIPTION
Adding the serving function for tf-part.

2 points:
- In model_trainer, I had to rewrite the forward_features function to workaround a bug. I created an internal bug to update the function.
- is_trainable is void for a keras model. I can explain why in our meeting but it might require some work to get it fixed. Maybe we should raise an exception when trainable=True and model=keras? Not sure where to insert that though.
