### PR TITLE
Train and evaluate

### DIFF
--- a/experiments/requirements.txt
+++ b/experiments/requirements.txt
@@ -22,7 +22,7 @@ requests==2.19.1
 scipy==1.1.0
 six==1.11.0
 tensorboard==1.8.0
-tensorflow==1.8.0
+tensorflow==1.10.0
 termcolor==1.1.0
 typed-ast==1.1.0
 urllib3==1.23

--- a/experiments/tf_trainer/common/model_trainer.py
+++ b/experiments/tf_trainer/common/model_trainer.py
@@ -185,41 +185,27 @@ class ModelTrainer(object):
       eval_period: the number of steps between evaluations.
       eval_steps: the number of batches that are evaluated per evaulation.
     """
-    experiment = None
-    if FLAGS.comet_key_file is not None:
-      experiment = self._setup_comet()
-    num_itr = int(steps / eval_period)
 
-    for _ in range(num_itr):
-      hooks = None
-      if FLAGS.enable_profiling:
-        hooks = [tf.train.ProfilerHook(save_steps=10,
-                                       output_dir=os.path.join(self._model_dir(), 'profiler'))]
-      self._estimator.train(
-          input_fn=self._dataset.train_input_fn,
-          steps=eval_period,
-          hooks=hooks)
-      metrics = self._estimator.evaluate(
-          input_fn=self._dataset.validate_input_fn, steps=eval_steps)
-      if experiment is not None:
-        tf.logging.info('Logging metrics to comet.ml: {}'.format(metrics))
-        experiment.log_multiple_metrics(metrics)
-      tf.logging.info(metrics)
+    training_hooks = None
+    if FLAGS.enable_profiling:
+      training_hooks = [tf.train.ProfilerHook(save_steps=10,
+          output_dir=os.path.join(self._model_dir(), 'profiler'))]
 
-  def _setup_comet(self):
-    with tf.gfile.GFile(FLAGS.comet_key_file) as key_file:
-      key = key_file.read().rstrip()
-    experiment = comet_ml.Experiment(
-        api_key=key,
-        project_name=FLAGS.comet_project_name,
-        workspace=FLAGS.comet_team_name,
-        auto_param_logging=False,
-        parse_args=False)
-    experiment.log_parameter('train_path', FLAGS.train_path)
-    experiment.log_parameter('validate_path', FLAGS.validate_path)
-    experiment.log_parameter('model_dir', self._model_dir())
-    experiment.log_multiple_params(self._model.hparams().values())
-    return experiment
+    train_spec = tf.estimator.TrainSpec(
+        input_fn=self._dataset.train_input_fn,
+        max_steps=steps,
+        hooks=training_hooks)
+    eval_spec = tf.estimator.EvalSpec(
+        input_fn=self._dataset.validate_input_fn,
+        steps=eval_steps,
+        start_delay_secs=1,
+        throttle_secs=1
+        )
+    self._estimator._config = self._estimator.config.replace(save_checkpoints_steps=eval_period)
+    tf.estimator.train_and_evaluate(
+        self._estimator,
+        train_spec,
+        eval_spec)
 
   def _model_dir(self):
     """Get Model Directory.

--- a/experiments/tf_trainer/common/model_trainer.py
+++ b/experiments/tf_trainer/common/model_trainer.py
@@ -13,7 +13,6 @@ import os
 import os.path
 import six
 
-import comet_ml
 import tensorflow as tf
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.estimator import estimator as estimator_lib
@@ -37,12 +36,6 @@ tf.app.flags.DEFINE_string('validate_path', None,
                            'Path to the validation data TFRecord file.')
 tf.app.flags.DEFINE_string('model_dir', None,
                            "Directory for the Estimator's model directory.")
-tf.app.flags.DEFINE_string('comet_key_file', None,
-                           'Path to file containing comet.ml api key.')
-tf.app.flags.DEFINE_string('comet_team_name', None,
-                           'Name of comet team that tracks results.')
-tf.app.flags.DEFINE_string('comet_project_name', None,
-                           'Name of comet project that tracks results.')
 tf.app.flags.DEFINE_bool('enable_profiling', False,
                            'Enable profiler hook in estimator.')
 
@@ -165,11 +158,7 @@ def forward_features(estimator, keys, sparse_default_values=None):
 
 
 class ModelTrainer(object):
-  """Model Trainer.
-
-  Convenient way to run a text classification estimator, supporting comet.ml
-  outputs.
-  """
+  """Model Trainer."""
 
   def __init__(self, dataset: ds.DatasetInput,
                model: base_model.BaseModel) -> None:

--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -57,7 +57,7 @@ class TFRecordInput(dataset_input.DatasetInput):
             {self._text_feature: [None],
             'sequence_length': []},
             {label: [] for label in self._labels})
-    # TODO(fprost_: Remove long sentences.
+    # TODO(fprost): Set a filter to remove long sentences (for training).
     parsed_dataset = parsed_dataset.apply(
         tf.contrib.data.bucket_by_sequence_length(
             element_length_func=lambda x,_: x['sequence_length'],

--- a/experiments/tf_trainer/keras_gru_attention/run.hyperparameter.sh
+++ b/experiments/tf_trainer/keras_gru_attention/run.hyperparameter.sh
@@ -15,11 +15,7 @@ GCS_RESOURCES="gs://kaggle-model-experiments/resources"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="keras_gru_attention"
 JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/${DATETIME}
-LOCAL_COMET_API_KEY_FILE="comet_api_key.txt"
-REMOTE_COMET_API_KEY_FILE=${GCS_RESOURCES}/${USER}_comet_api_key.txt
 
-gsutil cp ${LOCAL_COMET_API_KEY_FILE} ${REMOTE_COMET_API_KEY_FILE} &&
-gsutil acl set private ${REMOTE_COMET_API_KEY_FILE} &&
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \
     --runtime-version=1.8 \
@@ -32,7 +28,4 @@ gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIM
     --train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord" \
     --validate_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord" \
     --embeddings_path="${GCS_RESOURCES}/glove.6B/glove.6B.100d.txt" \
-    --model_dir="${JOB_DIR}/model_dir" \
-    --comet_key_file="${REMOTE_COMET_API_KEY_FILE}" \
-    --comet_team_name="jigsaw" \
-    --comet_project_name="experiments"
+    --model_dir="${JOB_DIR}/model_dir"

--- a/experiments/tf_trainer/keras_gru_attention/run.ml_engine.sh
+++ b/experiments/tf_trainer/keras_gru_attention/run.ml_engine.sh
@@ -15,11 +15,7 @@ GCS_RESOURCES="gs://kaggle-model-experiments/resources"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="keras_gru_attention"
 JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/${DATETIME}
-LOCAL_COMET_API_KEY_FILE="comet_api_key.txt"
-REMOTE_COMET_API_KEY_FILE=${GCS_RESOURCES}/${USER}_comet_api_key.txt
 
-gsutil cp ${LOCAL_COMET_API_KEY_FILE} ${REMOTE_COMET_API_KEY_FILE} &&
-gsutil acl set private ${REMOTE_COMET_API_KEY_FILE} &&
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \
     --runtime-version=1.10 \
@@ -33,7 +29,4 @@ gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIM
     --train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord" \
     --validate_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord" \
     --embeddings_path="${GCS_RESOURCES}/glove.6B/glove.6B.100d.txt" \
-    --model_dir="${JOB_DIR}/model_dir" \
-    --comet_key_file="${REMOTE_COMET_API_KEY_FILE}" \
-    --comet_team_name="jigsaw" \
-    --comet_project_name="experiments_${USER}"
+    --model_dir="${JOB_DIR}/model_dir"

--- a/experiments/tf_trainer/keras_gru_attention/run.ml_engine.sh
+++ b/experiments/tf_trainer/keras_gru_attention/run.ml_engine.sh
@@ -22,7 +22,7 @@ gsutil cp ${LOCAL_COMET_API_KEY_FILE} ${REMOTE_COMET_API_KEY_FILE} &&
 gsutil acl set private ${REMOTE_COMET_API_KEY_FILE} &&
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \
-    --runtime-version=1.8 \
+    --runtime-version=1.10 \
     --scale-tier 'BASIC_GPU' \
     --module-name="tf_trainer.${MODEL_NAME}.run" \
     --package-path=tf_trainer \

--- a/experiments/tf_trainer/tf_gru_attention/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_gru_attention/run.hyperparameter.sh
@@ -4,11 +4,7 @@ GCS_RESOURCES="gs://kaggle-model-experiments/resources"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_gru_attention"
 JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/${DATETIME}
-LOCAL_COMET_API_KEY_FILE="comet_api_key.txt"
-REMOTE_COMET_API_KEY_FILE=${GCS_RESOURCES}/${USER}_comet_api_key.txt
 
-gsutil cp ${LOCAL_COMET_API_KEY_FILE} ${REMOTE_COMET_API_KEY_FILE} &&
-gsutil acl set private ${REMOTE_COMET_API_KEY_FILE} &&
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \
     --runtime-version=1.8 \
@@ -21,7 +17,4 @@ gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIM
     --train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord" \
     --validate_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord" \
     --embeddings_path="${GCS_RESOURCES}/glove.6B/glove.6B.300d.txt" \
-    --model_dir="${JOB_DIR}/model_dir" \
-    --comet_key_file="${REMOTE_COMET_API_KEY_FILE}" \
-    --comet_team_name="jigsaw" \
-    --comet_project_name="experiments"
+    --model_dir="${JOB_DIR}/model_dir"

--- a/experiments/tf_trainer/tf_gru_attention/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_gru_attention/run.ml_engine.sh
@@ -23,7 +23,7 @@ gsutil cp ${LOCAL_COMET_API_KEY_FILE} ${REMOTE_COMET_API_KEY_FILE} &&
 gsutil acl set private ${REMOTE_COMET_API_KEY_FILE} &&
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \
-    --runtime-version=1.8 \
+    --runtime-version=1.10 \
     --scale-tier 'BASIC_GPU' \
     --module-name="tf_trainer.${MODEL_NAME}.run" \
     --package-path=tf_trainer \

--- a/experiments/tf_trainer/tf_gru_attention/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_gru_attention/run.ml_engine.sh
@@ -16,11 +16,7 @@ GCS_RESOURCES="gs://kaggle-model-experiments/resources"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_gru_attention"
 JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/${DATETIME}
-LOCAL_COMET_API_KEY_FILE="comet_api_key.txt"
-REMOTE_COMET_API_KEY_FILE=${GCS_RESOURCES}/${USER}_comet_api_key.txt
 
-gsutil cp ${LOCAL_COMET_API_KEY_FILE} ${REMOTE_COMET_API_KEY_FILE} &&
-gsutil acl set private ${REMOTE_COMET_API_KEY_FILE} &&
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \
     --runtime-version=1.10 \
@@ -35,7 +31,4 @@ gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIM
     --validate_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord" \
     --embeddings_path="${GCS_RESOURCES}/glove.6B/glove.6B.300d.txt" \
     --preprocess_in_tf=False \
-    --model_dir="${JOB_DIR}/model_dir" \
-    --comet_key_file="${REMOTE_COMET_API_KEY_FILE}" \
-    --comet_team_name="jigsaw" \
-    --comet_project_name="experiments"
+    --model_dir="${JOB_DIR}/model_dir"

--- a/experiments/tf_trainer/tf_gru_attention/run.py
+++ b/experiments/tf_trainer/tf_gru_attention/run.py
@@ -33,9 +33,9 @@ tf.app.flags.DEFINE_integer("batch_size", 32,
                             "The batch size to use during training.")
 tf.app.flags.DEFINE_integer("train_steps", 10000,
                             "The number of steps to train for.")
-tf.app.flags.DEFINE_integer("eval_period", 100,
+tf.app.flags.DEFINE_integer("eval_period", 200,
                             "The number of steps per eval period.")
-tf.app.flags.DEFINE_integer("eval_steps", 20,
+tf.app.flags.DEFINE_integer("eval_steps", 50,
                             "The number of steps to eval for.")
 
 # TODO: Missing fields are not handled properly yet.


### PR DESCRIPTION
This commit aims at correcting this bug: https://github.com/tensorflow/tensorflow/issues/19062.
The way to make the correction is to upgrade to tf==1.10 and to use train_and_evaluate.

Using train_and_evaluate removes the flexibility around the training loop. In particular, it is not easy anymore to include comet. We have removed it for now and could potentially be re-introduced via training_hooks.