### PR TITLE
Adding loading option

### DIFF
--- a/model_evaluation/jigsaw_evaluation_pipeline.ipynb
+++ b/model_evaluation/jigsaw_evaluation_pipeline.ipynb
@@ -342,7 +342,7 @@
     "SIZE_PERFORMANCE_DATA_SET = 10000\n",
     "\n",
     "# Pattern for path of tf_records\n",
-    "TF_RECORD_PERFORMANCE_PATTERN = os.path.join(\n",
+    "PERFORMANCE_DATASET_DIR = os.path.join(\n",
     "    'gs://kaggle-model-experiments/',\n",
     "    getpass.getuser(),\n",
     "    'tfrecords/test_performance')"
@@ -356,7 +356,7 @@
    },
    "outputs": [],
    "source": [
-    "dataset_performance = Dataset(input_fn_performance)\n",
+    "dataset_performance = Dataset(input_fn_performance, PERFORMANCE_DATASET_DIR)\n",
     "dataset_performance.load_data(SIZE_PERFORMANCE_DATA_SET, random_filter_keep_rate=0.5)"
    ]
   },
@@ -366,7 +366,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_performance.add_model_prediction_to_data(model, tf_record_path_pattern=TF_RECORD_PERFORMANCE_PATTERN)"
+    "dataset_performance.add_model_prediction_to_data(model)"
    ]
   },
   {
@@ -386,7 +386,7 @@
     "SIZE_PERFORMANCE_DATA_SET = None\n",
     "\n",
     "# Pattern for path of tf_records\n",
-    "TF_RECORD_BIAS_PATTERN = os.path.join(\n",
+    "BIAS_DATASET_DIR = os.path.join(\n",
     "    'gs://kaggle-model-experiments/',\n",
     "    getpass.getuser(),\n",
     "    'tfrecords/bias_performance')"
@@ -398,7 +398,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_bias = Dataset(input_fn_bias)\n",
+    "dataset_bias = Dataset(input_fn_bias, BIAS_DATASET_DIR)\n",
     "dataset_bias.load_data(SIZE_PERFORMANCE_DATA_SET)"
    ]
   },
@@ -408,7 +408,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_bias.add_model_prediction_to_data(model, tf_record_path_pattern=TF_RECORD_BIAS_PATTERN)"
+    "dataset_bias.add_model_prediction_to_data(model)"
    ]
   },
   {
@@ -823,7 +823,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/model_evaluation/utils_export/dataset_test.py
+++ b/model_evaluation/utils_export/dataset_test.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import getpass
 import os
+import time
 import unittest
 
 from dataset import Dataset
@@ -140,6 +141,8 @@ class TestModelCompatibleWithInputFn(unittest.TestCase):
 class TestEndPipeline(unittest.TestCase):
   """Verifies end-to-end use of dataset."""
 
+  test_version = str(int(time.time()))
+
   def setUp(self):
     def input_fn_test(max_n_examples):
       return pd.DataFrame({
@@ -147,7 +150,8 @@ class TestEndPipeline(unittest.TestCase):
       })
 
     gcs_path_test = os.path.join('gs://kaggle-model-experiments/',
-                                 getpass.getuser(), 'unittest')
+                                 getpass.getuser(), 'unittest', 'dataset_test',
+                                 TestEndPipeline.test_version)
     self.dataset = Dataset(input_fn_test, gcs_path_test)
     self.dataset.load_data(5)
 
@@ -166,7 +170,7 @@ class TestEndPipeline(unittest.TestCase):
 
   def testComputePredictions(self):
     try:
-      self.dataset.add_model_prediction_to_data(self.model) 
+      self.dataset.add_model_prediction_to_data(self.model)
     except ValueError :
       self.fail('Dataset raised an exception unexpectedly!')
 


### PR DESCRIPTION
Restructuring the code to add one feature "Loading". 

Feature description:
When we call the method dataset.add_model_prediction_to_data(model) we now have an extra argument 'recompute_predictions'.
If set to False, we reload past prediction instead of rerunning the entire pipeline.

Design changes:
- Clarification of the file names. A dataset has now a 'dataset_dir' where all the files will be saved (input_tf_records and output_predictions).
- Adding good tests for the entire pipeline in dataset_test.py
The rest are minor changes to keep a clean flow.

Thank you for the review.
