### PR TITLE
Address security alerts for request package

### DIFF
--- a/annotator-models/requirements.txt
+++ b/annotator-models/requirements.txt
@@ -66,7 +66,7 @@ pyasn1==0.4.2
 pyasn1-modules==0.2.1
 python-dateutil==2.7.2
 pytz==2018.3
-requests==2.18.4
+requests==2.20.0
 requests-oauthlib==0.8.0
 rsa==3.4.2
 six==1.11.0

--- a/attention-tutorial/requirements.txt
+++ b/attention-tutorial/requirements.txt
@@ -47,7 +47,7 @@ pytz==2017.3
 PyYAML==3.12
 pyzmq==17.0.0
 qtconsole==4.3.1
-requests==2.18.4
+requests==2.20.0
 scikit-learn==0.19.1
 scipy==1.0.0
 Send2Trash==1.5.0

--- a/experiments/requirements.txt
+++ b/experiments/requirements.txt
@@ -18,7 +18,7 @@ nltk==3.3
 numpy==1.14.4
 protobuf==3.6.0
 PyYAML==3.12
-requests==2.19.1
+requests==2.20.0
 scipy==1.1.0
 six==1.11.0
 tensorboard==1.8.0

--- a/kaggle-classification/requirements.txt
+++ b/kaggle-classification/requirements.txt
@@ -23,7 +23,7 @@ protobuf==3.5.1
 python-dateutil==2.6.1
 pytz==2017.3
 PyYAML==3.12
-requests==2.18.4
+requests==2.20.0
 scikit-learn==0.19.1
 scipy==1.0.0
 six==1.11.0

--- a/model_evaluation/requirements.txt
+++ b/model_evaluation/requirements.txt
@@ -3,7 +3,7 @@ Markdown==2.6.11
 nltk==3.3
 numpy==1.14.4
 pandas==0.22.0
-requests==2.19.1
+requests==2.20.0
 seaborn==0.8.1
 scikit-learn==0.19.1
 scipy==1.1.0


### PR DESCRIPTION
This change just updates the requests package to the minimum level to address the
security alerts. I tested it only minimally, but expect that it should be fine.