### PR TITLE
Add missing copyright headers to files

### DIFF
--- a/experiments/tf_trainer/common/base_keras_model.py
+++ b/experiments/tf_trainer/common/base_keras_model.py
@@ -1,3 +1,17 @@
+# coding=utf-8
+# Copyright 2018 The Conversation-AI.github.io Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Abstract Base Class for Keras Models."""
 
 from __future__ import absolute_import

--- a/experiments/tf_trainer/common/base_keras_model_test.py
+++ b/experiments/tf_trainer/common/base_keras_model_test.py
@@ -1,3 +1,17 @@
+# coding=utf-8
+# Copyright 2018 The Conversation-AI.github.io Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Tests for BaseKerasModel."""
 
 from __future__ import absolute_import

--- a/experiments/tf_trainer/common/base_model.py
+++ b/experiments/tf_trainer/common/base_model.py
@@ -1,3 +1,17 @@
+# coding=utf-8
+# Copyright 2018 The Conversation-AI.github.io Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Interface for Models."""
 
 from __future__ import absolute_import

--- a/experiments/tf_trainer/common/dataset_input.py
+++ b/experiments/tf_trainer/common/dataset_input.py
@@ -1,3 +1,17 @@
+# coding=utf-8
+# Copyright 2018 The Conversation-AI.github.io Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Abstract Base Class for DatasetInput."""
 
 from __future__ import absolute_import

--- a/experiments/tf_trainer/common/model_trainer.py
+++ b/experiments/tf_trainer/common/model_trainer.py
@@ -1,3 +1,17 @@
+# coding=utf-8
+# Copyright 2018 The Conversation-AI.github.io Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """The Model Trainer class.
 
 This provides an abstraction of Keras and TF.Estimator, and is intended for use

--- a/experiments/tf_trainer/common/tfrecord_input_test.py
+++ b/experiments/tf_trainer/common/tfrecord_input_test.py
@@ -1,3 +1,17 @@
+# coding=utf-8
+# Copyright 2018 The Conversation-AI.github.io Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Tests for tfrecord_input."""
 
 from __future__ import absolute_import

--- a/experiments/tf_trainer/common/types.py
+++ b/experiments/tf_trainer/common/types.py
@@ -1,3 +1,17 @@
+# coding=utf-8
+# Copyright 2018 The Conversation-AI.github.io Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Types for the tf_trainer module."""
 
 from __future__ import absolute_import

--- a/experiments/tools/convert_csv_to_tfrecord.py
+++ b/experiments/tools/convert_csv_to_tfrecord.py
@@ -1,3 +1,17 @@
+# coding=utf-8
+# Copyright 2018 The Conversation-AI.github.io Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """A function to convert csvs to TFRecords."""
 
 from __future__ import absolute_import


### PR DESCRIPTION
Note that every code file should have the corresponding google copyright header. I'm adding a bunch here. 