### PR TITLE
Expand tf hub to do multiple labels

### DIFF
--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -74,6 +74,18 @@ class TFRecordInput(dataset_input.DatasetInput):
     batched_dataset = batched_dataset.prefetch(self._num_prefetch)
     return batched_dataset
 
+  def _process_labels(self, features, parsed):
+    labels = {}
+    for label in self._labels:
+      label_value = parsed[label]
+      # Missing weights are negative, find them and zero those features out.
+      weight = tf.cast(tf.greater_equal(label_value, 0.0), dtype=tf.float32)
+      if self._round_labels:
+        label_value = tf.round(label_value)
+      features[label + '_weight'] = weight
+      labels[label] = tf.multiply(label_value, weight)
+    return features, labels
+
   def _read_tf_example(
       self,
       record: tf.Tensor,
@@ -92,12 +104,7 @@ class TFRecordInput(dataset_input.DatasetInput):
         record, keys_to_features)  # type: Dict[str, types.Tensor]
 
     features = {base_model.TEXT_FEATURE_KEY: parsed[self._text_feature]}
-    labels = {}
-    for label in self._labels:
-      labels[label] = parsed[label]
-      if self._round_labels:
-        labels[label] = tf.round(labels[label])
-    return features, labels
+    return self._process_labels(features, parsed)
 
 
 class TFRecordInputWithTokenizer(TFRecordInput):
@@ -167,9 +174,4 @@ class TFRecordInputWithTokenizer(TFRecordInput):
         base_model.TOKENS_FEATURE_KEY: tokens,
         'sequence_length': tf.shape(tokens)[0],
     }
-    if self._round_labels:
-      labels = {label: tf.round(parsed[label]) for label in self._labels}
-    else:
-      labels = {label: parsed[label] for label in self._labels}
-
-    return features, labels
+    return self._process_labels(features, parsed)

--- a/experiments/tf_trainer/common/tfrecord_input_test.py
+++ b/experiments/tf_trainer/common/tfrecord_input_test.py
@@ -60,7 +60,9 @@ class TFRecordInputTest(tf.test.TestCase):
       self.assertEqual(features[base_model.TEXT_FEATURE_KEY].eval(),
                        b'Hi there Bob')
       np.testing.assert_almost_equal(labels['label'].eval(), 0.8)
-      self.assertEqual(list(labels), ['label'])
+      np.testing.assert_almost_equal(features['label_weight'].eval(), 1.0)
+      self.assertCountEqual(list(labels), ['label'])
+      self.assertCountEqual(list(features), ['text', 'label_weight'])
 
   def test_TFRecordInput_default_values(self):
     FLAGS.labels = 'label,fake_label'
@@ -72,7 +74,9 @@ class TFRecordInputTest(tf.test.TestCase):
       self.assertEqual(features[base_model.TEXT_FEATURE_KEY].eval(),
                        b'Hi there Bob')
       np.testing.assert_almost_equal(labels['label'].eval(), 0.8)
-      np.testing.assert_almost_equal(labels['fake_label'].eval(), -1.0)
+      np.testing.assert_almost_equal(features['label_weight'].eval(), 1.0)
+      np.testing.assert_almost_equal(labels['fake_label'].eval(), 0.0)
+      np.testing.assert_almost_equal(features['fake_label_weight'].eval(), 0.0)
 
   def test_TFRecordInput_rounded(self):
     FLAGS.labels = 'label'
@@ -84,9 +88,7 @@ class TFRecordInputTest(tf.test.TestCase):
       self.assertEqual(features[base_model.TEXT_FEATURE_KEY].eval(),
                        b'Hi there Bob')
       np.testing.assert_almost_equal(labels['label'].eval(), 1.0)
-
-if __name__ == '__main__':
-  tf.test.main()
+      np.testing.assert_almost_equal(features['label_weight'].eval(), 1.0)
 
 
 class TFRecordInputWithTokenizerTest(tf.test.TestCase):
@@ -115,7 +117,7 @@ class TFRecordInputWithTokenizerTest(tf.test.TestCase):
                               for x in t.decode('utf-8').split(" ")]),
         [text], tf.int64)
 
-  def test_TFRecordInput_unrounded(self):
+  def test_TFRecordInputWithTokenzier_unrounded(self):
     FLAGS.labels = "label"
     FLAGS.round_labels = False
     dataset_input = tfrecord_input.TFRecordInput(
@@ -126,6 +128,7 @@ class TFRecordInputWithTokenizerTest(tf.test.TestCase):
       self.assertEqual(list(features[base_model.TOKENS_FEATURE_KEY].eval()),
                        [12, 13, 999])
       self.assertAlmostEqual(labels["label"].eval(), 0.8)
+      self.assertAlmostEqual(features["label_weight"].eval(), 1.0)
 
   def test_TFRecordInputWithTokenizer_default_values(self):
     FLAGS.labels = "label,fake_label"
@@ -138,7 +141,9 @@ class TFRecordInputWithTokenizerTest(tf.test.TestCase):
       self.assertEqual(list(features[base_model.TOKENS_FEATURE_KEY].eval()),
                        [12, 13, 999])
       self.assertAlmostEqual(labels["label"].eval(), 0.8)
-      self.assertAlmostEqual(labels["fake_label"].eval(), -1.0)
+      self.assertAlmostEqual(labels["fake_label"].eval(), 0.0)
+      self.assertAlmostEqual(features["label_weight"].eval(), 1.0)
+      self.assertAlmostEqual(features["fake_label_weight"].eval(), 1.0)
 
   def test_TFRecordInputWithTokenizer_rounded(self):
     FLAGS.labels = "label"
@@ -151,6 +156,7 @@ class TFRecordInputWithTokenizerTest(tf.test.TestCase):
       self.assertEqual(list(features[base_model.TOKENS_FEATURE_KEY].eval()),
                        [12, 13, 999])
       self.assertEqual(labels["label"].eval(), 1.0)
+      self.assertEqual(features["label_weight"].eval(), 1.0)
 
 if __name__ == "__main__":
   tf.test.main()

--- a/experiments/tf_trainer/common/tfrecord_input_test.py
+++ b/experiments/tf_trainer/common/tfrecord_input_test.py
@@ -143,7 +143,7 @@ class TFRecordInputWithTokenizerTest(tf.test.TestCase):
       self.assertAlmostEqual(labels["label"].eval(), 0.8)
       self.assertAlmostEqual(labels["fake_label"].eval(), 0.0)
       self.assertAlmostEqual(features["label_weight"].eval(), 1.0)
-      self.assertAlmostEqual(features["fake_label_weight"].eval(), 1.0)
+      self.assertAlmostEqual(features["fake_label_weight"].eval(), 0.0)
 
   def test_TFRecordInputWithTokenizer_rounded(self):
     FLAGS.labels = "label"

--- a/experiments/tf_trainer/tf_hub_classifier/model.py
+++ b/experiments/tf_trainer/tf_hub_classifier/model.py
@@ -67,7 +67,8 @@ class TFHubClassifierModel(base_model.BaseModel):
         inputs=logits, units=len(self._target_labels), activation=None)
 
     output_heads = [
-        tf.contrib.estimator.binary_classification_head(name=name)
+        tf.contrib.estimator.binary_classification_head(
+            name=name, weight_column=name + '_weight')
         for name in self._target_labels
     ]
     multihead = tf.contrib.estimator.multi_head(output_heads)

--- a/experiments/tf_trainer/tf_hub_classifier/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_hub_classifier/run.hyperparameter.sh
@@ -19,4 +19,6 @@ gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIM
     --model_dir="${JOB_DIR}/model_dir" \
     --is_embedding_trainable False \
     --train_steps=40000 \
-    --eval_period=800
+    --eval_period=800 \
+    --labels=frac_neg,frac_very_neg,sexual_orientation,health_age_disability,gender,religion,rne,obscene,threat,insult,identity_hate,flirtation,sexual_explicit
+

--- a/experiments/tf_trainer/tf_hub_classifier/run.local.sh
+++ b/experiments/tf_trainer/tf_hub_classifier/run.local.sh
@@ -5,5 +5,5 @@ GCS_RESOURCES="gs://kaggle-model-experiments/resources"
 python -m tf_trainer.tf_hub_classifier.run \
   --train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord" \
   --validate_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord" \
-  --embeddings_path="${GCS_RESOURCES}/glove.6B/glove.6B.100d.txt" \
-  --model_dir="tf_hub_classifier_local_model_dir"
+  --model_dir="tf_hub_classifier_local_model_dir" \
+  --labels=frac_neg,frac_very_neg,sexual_orientation,health_age_disability,gender,religion,rne,obscene,threat,insult,identity_hate,flirtation,sexual_explicit

--- a/experiments/tf_trainer/tf_hub_classifier/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_hub_classifier/run.ml_engine.sh
@@ -20,4 +20,5 @@ gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIM
     --train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord" \
     --validate_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord" \
     --model_dir="${JOB_DIR}/model_dir" \
-    --n_export=7
+    --n_export=7 \
+    --labels=frac_neg,frac_very_neg,sexual_orientation,health_age_disability,gender,religion,rne,obscene,threat,insult,identity_hate,flirtation,sexual_explicit

--- a/experiments/tf_trainer/tf_hub_classifier/run.py
+++ b/experiments/tf_trainer/tf_hub_classifier/run.py
@@ -14,13 +14,13 @@ import tensorflow as tf
 
 FLAGS = tf.app.flags.FLAGS
 
-tf.app.flags.DEFINE_integer("batch_size", 32,
+tf.app.flags.DEFINE_integer("batch_size", 256,
                             "The batch size to use during training.")
 tf.app.flags.DEFINE_integer("train_steps", 40000,
                             "The number of steps to train for.")
-tf.app.flags.DEFINE_integer("eval_period", 500,
+tf.app.flags.DEFINE_integer("eval_period", 1000,
                             "The number of steps per eval period.")
-tf.app.flags.DEFINE_integer("eval_steps", 50,
+tf.app.flags.DEFINE_integer("eval_steps", 350,
                             "The number of steps to eval for.")
 
 

--- a/experiments/tf_trainer/tf_hub_classifier/run.py
+++ b/experiments/tf_trainer/tf_hub_classifier/run.py
@@ -61,8 +61,7 @@ def main(argv):
   trainer = model_trainer.ModelTrainer(dataset, model)
   trainer.train_with_eval(FLAGS.train_steps, FLAGS.eval_period, FLAGS.eval_steps)
 
-  serving_input_fn = create_serving_input_fn(
-      text_feature_name=dataset.text_feature())
+  serving_input_fn = create_serving_input_fn()
   trainer.export(serving_input_fn)
 
 


### PR DESCRIPTION
Entries that have missing labels will not back propagate their corrections for the missing entries.