### PR TITLE
Moveflags

### DIFF
--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -60,7 +60,7 @@ class TFRecordInput(dataset_input.DatasetInput):
   def train_input_fn(self) -> types.FeatureAndLabelTensors:
     """input_fn for TF Estimators for training set.
 
-    Automatically repeats indefinitely.
+    Automatically repeats over input data forever.
     """
     assert FLAGS.train_path
     return self._input_fn_from_file(FLAGS.train_path).repeat()
@@ -143,9 +143,8 @@ class TFRecordInputWithTokenizer(TFRecordInput):
 
   def __init__(self,
                train_preprocess_fn: Callable[[str], List[str]],
-               num_prefetch: int = 5,
                max_seq_len: int = 30000) -> None:
-    super().__init__(num_prefetch)
+    super().__init__()
     self._train_preprocess_fn = train_preprocess_fn
     self._max_seq_len = max_seq_len
 

--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -23,6 +23,10 @@ tf.app.flags.DEFINE_string('text_feature', 'comment_text',
                            'Name of feature containing text input.')
 tf.app.flags.DEFINE_boolean('round_labels', True,
                             'Round label features to 0 or 1 if true.')
+tf.app.flags.DEFINE_integer('batch_size', 256,
+                            'Batch sizes to use when reading.')
+tf.app.flags.DEFINE_integer('num_prefetch', 5,
+                            'Batch sizes to use when reading.')
 
 
 FLAGS = tf.app.flags.FLAGS
@@ -38,12 +42,10 @@ class TFRecordInput(dataset_input.DatasetInput):
   the feature key _text_feature.
   """
 
-  def __init__(self,
-               batch_size: int = 64,
-               num_prefetch: int = 5) ->None:
+  def __init__(self) -> None:
     self._labels = FLAGS.labels.split(',')
-    self._batch_size = batch_size
-    self._num_prefetch = num_prefetch
+    self._batch_size = FLAGS.batch_size
+    self._num_prefetch = FLAGS.num_prefetch
     self._text_feature = FLAGS.text_feature
     self._round_labels = FLAGS.round_labels
 
@@ -56,9 +58,12 @@ class TFRecordInput(dataset_input.DatasetInput):
     return self._text_feature
 
   def train_input_fn(self) -> types.FeatureAndLabelTensors:
-    """input_fn for TF Estimators for training set."""
+    """input_fn for TF Estimators for training set.
+
+    Automatically repeats indefinitely.
+    """
     assert FLAGS.train_path
-    return self._input_fn_from_file(FLAGS.train_path)
+    return self._input_fn_from_file(FLAGS.train_path).repeat()
 
   def validate_input_fn(self) -> types.FeatureAndLabelTensors:
     """input_fn for TF Estimators for validation set."""
@@ -70,7 +75,7 @@ class TFRecordInput(dataset_input.DatasetInput):
     parsed_dataset = dataset.map(
         self._read_tf_example,
         num_parallel_calls=multiprocessing.cpu_count())
-    return parsed_dataset.repeat().batch(self._batch_size).prefetch(
+    return parsed_dataset.batch(self._batch_size).prefetch(
         self._num_prefetch)
 
   def _process_labels(self, features, parsed):
@@ -138,17 +143,15 @@ class TFRecordInputWithTokenizer(TFRecordInput):
 
   def __init__(self,
                train_preprocess_fn: Callable[[str], List[str]],
-               batch_size: int = 64,
                num_prefetch: int = 5,
                max_seq_len: int = 30000) -> None:
-    super().__init__(batch_size, num_prefetch)
+    super().__init__(num_prefetch)
     self._train_preprocess_fn = train_preprocess_fn
     self._max_seq_len = max_seq_len
 
   def _input_fn_from_file(self, filepath: str) -> types.FeatureAndLabelTensors:
 
     filenames_dataset = tf.data.Dataset.list_files(filepath)
-    filenames_dataset = filenames_dataset.repeat(None)
     dataset = tf.data.TFRecordDataset(filenames_dataset) # type: tf.data.TFRecordDataset
 
     parsed_dataset = dataset.map(

--- a/experiments/tf_trainer/keras_cnn/run.py
+++ b/experiments/tf_trainer/keras_cnn/run.py
@@ -21,35 +21,24 @@ FLAGS = tf.app.flags.FLAGS
 tf.app.flags.DEFINE_string("embeddings_path",
                            "local_data/glove.6B/glove.6B.100d.txt",
                            "Path to the embeddings file.")
-tf.app.flags.DEFINE_integer("batch_size", 64,
-                            "The batch size to use during training.")
-tf.app.flags.DEFINE_integer("train_steps", 5000,
-                            "The number of steps to train for.")
-tf.app.flags.DEFINE_integer("eval_period", 200,
-                            "The number of steps per eval period.")
-tf.app.flags.DEFINE_integer("eval_steps", 100,
-                            "The number of steps to eval for.")
 
 
 def main(argv):
   del argv  # unused
 
-  embeddings_path = FLAGS.embeddings_path
-
-  preprocessor = text_preprocessor.TextPreprocessor(embeddings_path)
+  preprocessor = text_preprocessor.TextPreprocessor(FLAGS.embeddings_path)
 
   nltk.download("punkt")
   train_preprocess_fn = preprocessor.train_preprocess_fn(nltk.word_tokenize)
   dataset = tfrecord_input.TFRecordInputWithTokenizer(
-      train_preprocess_fn=train_preprocess_fn,
-      batch_size=FLAGS.batch_size)
+      train_preprocess_fn=train_preprocess_fn)
 
   # TODO: Move embedding *into* Keras model.
   model = preprocessor.add_embedding_to_model(
       keras_cnn.KerasCNNModel(dataset.labels()), base_model.TOKENS_FEATURE_KEY)
 
   trainer = model_trainer.ModelTrainer(dataset, model)
-  trainer.train_with_eval(FLAGS.train_steps, FLAGS.eval_period, FLAGS.eval_steps)
+  trainer.train_with_eval()
 
 
 if __name__ == "__main__":

--- a/experiments/tf_trainer/keras_gru_attention/run.py
+++ b/experiments/tf_trainer/keras_gru_attention/run.py
@@ -21,28 +21,17 @@ FLAGS = tf.app.flags.FLAGS
 tf.app.flags.DEFINE_string("embeddings_path",
                            "local_data/glove.6B/glove.6B.100d.txt",
                            "Path to the embeddings file.")
-tf.app.flags.DEFINE_integer("batch_size", 32,
-                            "The batch size to use during training.")
-tf.app.flags.DEFINE_integer("train_steps", 10000,
-                            "The number of steps to train for.")
-tf.app.flags.DEFINE_integer("eval_period", 100,
-                            "The number of steps per eval period.")
-tf.app.flags.DEFINE_integer("eval_steps", 20,
-                            "The number of steps to eval for.")
 
 
 def main(argv):
   del argv  # unused
 
-  embeddings_path = FLAGS.embeddings_path
-
-  preprocessor = text_preprocessor.TextPreprocessor(embeddings_path)
+  preprocessor = text_preprocessor.TextPreprocessor(FLAGS.embeddings_path)
 
   nltk.download("punkt")
   train_preprocess_fn = preprocessor.train_preprocess_fn(nltk.word_tokenize)
   dataset = tfrecord_input.TFRecordInputWithTokenizer(
-      train_preprocess_fn=train_preprocess_fn,
-      batch_size=FLAGS.batch_size)
+      train_preprocess_fn=train_preprocess_fn)
 
   # TODO: Move embedding *into* Keras model.
   model_keras = keras_gru_attention.KerasRNNModel(
@@ -52,7 +41,7 @@ def main(argv):
       model_keras, base_model.TOKENS_FEATURE_KEY)
 
   trainer = model_trainer.ModelTrainer(dataset, model)
-  trainer.train_with_eval(FLAGS.train_steps, FLAGS.eval_period, FLAGS.eval_steps)
+  trainer.train_with_eval()
 
   serving_input_fn = serving_input.create_serving_input_fn(
       word_to_idx=preprocessor._word_to_idx,

--- a/experiments/tf_trainer/tf_gru_attention/run.local.sh
+++ b/experiments/tf_trainer/tf_gru_attention/run.local.sh
@@ -18,7 +18,7 @@ python -m tf_trainer.tf_gru_attention.run \
   --validate_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord" \
   --embeddings_path="${GCS_RESOURCES}/glove.6B/glove.6B.100d.txt" \
   --model_dir="tf_gru_attention_local_model_dir" \
-  --labels="toxicity"
+  --labels="toxicity,sever_toxicity,obscene,sexual_explicit,identity_attack,insult,threat"
 
 
 

--- a/experiments/tf_trainer/tf_gru_attention/run.py
+++ b/experiments/tf_trainer/tf_gru_attention/run.py
@@ -22,14 +22,6 @@ FLAGS = tf.app.flags.FLAGS
 tf.app.flags.DEFINE_string("embeddings_path",
                            "local_data/glove.6B/glove.6B.100d.txt",
                            "Path to the embeddings file.")
-tf.app.flags.DEFINE_integer("batch_size", 32,
-                            "The batch size to use during training.")
-tf.app.flags.DEFINE_integer("train_steps", 100000,
-                            "The number of steps to train for.")
-tf.app.flags.DEFINE_integer("eval_period", 800,
-                            "The number of steps per eval period.")
-tf.app.flags.DEFINE_integer("eval_steps", 50,
-                            "The number of steps to eval for.")
 
 
 def main(argv):
@@ -42,8 +34,7 @@ def main(argv):
   nltk.download("punkt")
   train_preprocess_fn = preprocessor.train_preprocess_fn(nltk.word_tokenize)
   dataset = tfrecord_input.TFRecordInputWithTokenizer(
-      train_preprocess_fn=train_preprocess_fn,
-      batch_size=FLAGS.batch_size)
+      train_preprocess_fn=train_preprocess_fn)
 
   # TODO: Move embedding *into* Keras model.
   model_tf = tf_gru_attention.TFRNNModel(dataset.labels())
@@ -51,7 +42,7 @@ def main(argv):
       model_tf, base_model.TOKENS_FEATURE_KEY)
 
   trainer = model_trainer.ModelTrainer(dataset, model)
-  trainer.train_with_eval(FLAGS.train_steps, FLAGS.eval_period, FLAGS.eval_steps)
+  trainer.train_with_eval()
 
   serving_input_fn = serving_input.create_serving_input_fn(
       word_to_idx=preprocessor._word_to_idx,

--- a/experiments/tf_trainer/tf_hub_classifier/run.py
+++ b/experiments/tf_trainer/tf_hub_classifier/run.py
@@ -14,15 +14,6 @@ import tensorflow as tf
 
 FLAGS = tf.app.flags.FLAGS
 
-tf.app.flags.DEFINE_integer("batch_size", 32,
-                            "The batch size to use during training.")
-tf.app.flags.DEFINE_integer("train_steps", 40000,
-                            "The number of steps to train for.")
-tf.app.flags.DEFINE_integer("eval_period", 500,
-                            "The number of steps per eval period.")
-tf.app.flags.DEFINE_integer("eval_steps", 50,
-                            "The number of steps to eval for.")
-
 
 def create_serving_input_fn():
 
@@ -53,13 +44,11 @@ def create_serving_input_fn():
 def main(argv):
   del argv  # unused
 
-  dataset = tfrecord_input.TFRecordInput(
-      batch_size=FLAGS.batch_size)
-
+  dataset = tfrecord_input.TFRecordInput()
   model = tf_hub_classifier.TFHubClassifierModel(dataset.labels())
 
   trainer = model_trainer.ModelTrainer(dataset, model)
-  trainer.train_with_eval(FLAGS.train_steps, FLAGS.eval_period, FLAGS.eval_steps)
+  trainer.train_with_eval()
 
   serving_input_fn = create_serving_input_fn()
   trainer.export(serving_input_fn)

--- a/experiments/tf_trainer/tf_word_label_embedding/run.py
+++ b/experiments/tf_trainer/tf_word_label_embedding/run.py
@@ -21,28 +21,17 @@ FLAGS = tf.app.flags.FLAGS
 tf.app.flags.DEFINE_string('embeddings_path',
                            'local_data/glove.6B/glove.6B.100d.txt',
                            'Path to the embeddings file.')
-tf.app.flags.DEFINE_integer('batch_size', 64,
-                            'The batch size to use during training.')
-tf.app.flags.DEFINE_integer('train_steps', 30000,
-                            'The number of steps to train for.')
-tf.app.flags.DEFINE_integer('eval_period', 500,
-                            'The number of steps per eval period.')
-tf.app.flags.DEFINE_integer('eval_steps', 50,
-                            'The number of steps to eval for.')
 
 
 def main(argv):
   del argv  # unused
 
-  embeddings_path = FLAGS.embeddings_path
-
-  preprocessor = text_preprocessor.TextPreprocessor(embeddings_path)
+  preprocessor = text_preprocessor.TextPreprocessor(FLAGS.embeddings_path)
 
   nltk.download('punkt')
   train_preprocess_fn = preprocessor.train_preprocess_fn(nltk.word_tokenize)
   dataset = tfrecord_input.TFRecordInputWithTokenizer(
       train_preprocess_fn=train_preprocess_fn,
-      batch_size=FLAGS.batch_size,
       max_seq_len=5000)
 
   model_tf = tf_word_label_embedding.TFWordLabelEmbeddingModel(
@@ -51,8 +40,7 @@ def main(argv):
       model_tf, base_model.TOKENS_FEATURE_KEY)
 
   trainer = model_trainer.ModelTrainer(dataset, model)
-  trainer.train_with_eval(FLAGS.train_steps, FLAGS.eval_period,
-                          FLAGS.eval_steps)
+  trainer.train_with_eval()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Moves most of the training related flag definitions to where they are used.

Configurations should be injected via structures where possible. In this case, the properties
of the training set - the locations of the files, and the sizes of the batches are typically more
closely associated with training data itself rather than the model.

Currently we are accessing flags that are defined in duplicate in several places. This flag
duplication is very brittle. So it's preferable to define the flags where they are use to increase
encapsulation.

Eventually we will move to a model that describes all of the flags associated with a
particular training set as one structure.
