### PR TITLE
Add label dtypes

### DIFF
--- a/experiments/tf_trainer/common/tfrecord_input_test.py
+++ b/experiments/tf_trainer/common/tfrecord_input_test.py
@@ -69,6 +69,7 @@ class TFRecordInputTest(tf.test.TestCase):
 
   def test_TFRecordInput_default_values(self):
     FLAGS.labels = 'label,fake_label,int_label'
+    FLAGS.label_dtypes = 'float,float,int'
     FLAGS.round_labels = False
     dataset_input = tfrecord_input.TFRecordInput()
 
@@ -98,34 +99,35 @@ class TFRecordInputTest(tf.test.TestCase):
 class TFRecordInputWithTokenizerTest(tf.test.TestCase):
 
   def setUp(self):
-    FLAGS.text_feature = "comment"
+    FLAGS.text_feature = 'comment'
     ex = tf.train.Example(
       features=tf.train.Features(
           feature={
-              "label":
+              'label':
                   tf.train.Feature(
                       float_list=tf.train.FloatList(value=[0.8])),
-              "int_label":
+              'int_label':
                   tf.train.Feature(
                       int64_list=tf.train.Int64List(value=[0])),
-              "comment":
+              'comment':
                   tf.train.Feature(
                       bytes_list=tf.train.BytesList(
-                          value=["Hi there Bob".encode("utf-8")]))
+                          value=['Hi there Bob'.encode('utf-8')]))
                   }))
     self.ex_tensor = tf.convert_to_tensor(ex.SerializeToString(), dtype=tf.string)
 
-    self.word_to_idx = {"Hi": 12, "there": 13}
+    self.word_to_idx = {'Hi': 12, 'there': 13}
     self.unknown_token = 999
 
   def preprocessor(self, text):
     return tf.py_func(
         lambda t: np.asarray([self.word_to_idx.get(x, self.unknown_token)
-                              for x in t.decode('utf-8').split(" ")]),
+                              for x in t.decode('utf-8').split(' ')]),
         [text], tf.int64)
 
   def test_TFRecordInputWithTokenizer_unrounded(self):
-    FLAGS.labels = "label,int_label"
+    FLAGS.labels = 'label,int_label'
+    FLAGS.label_dtypes = 'float,int'
     FLAGS.round_labels = False
     dataset_input = tfrecord_input.TFRecordInputWithTokenizer(
         train_preprocess_fn=self.preprocessor)
@@ -134,12 +136,12 @@ class TFRecordInputWithTokenizerTest(tf.test.TestCase):
       features, labels = dataset_input._read_tf_example(self.ex_tensor)
       self.assertEqual(list(features[base_model.TOKENS_FEATURE_KEY].eval()),
                        [12, 13, 999])
-      self.assertAlmostEqual(labels["label"].eval(), 0.8)
-      self.assertAlmostEqual(labels["int_label"].eval(), 0.0)
-      self.assertAlmostEqual(features["label_weight"].eval(), 1.0)
+      self.assertAlmostEqual(labels['label'].eval(), 0.8)
+      self.assertAlmostEqual(labels['int_label'].eval(), 0.0)
+      self.assertAlmostEqual(features['label_weight'].eval(), 1.0)
 
   def test_TFRecordInputWithTokenizer_default_values(self):
-    FLAGS.labels = "label,fake_label"
+    FLAGS.labels = 'label,fake_label'
     FLAGS.round_labels = False
     dataset_input = tfrecord_input.TFRecordInputWithTokenizer(
         train_preprocess_fn=self.preprocessor)
@@ -148,13 +150,13 @@ class TFRecordInputWithTokenizerTest(tf.test.TestCase):
       features, labels = dataset_input._read_tf_example(self.ex_tensor)
       self.assertEqual(list(features[base_model.TOKENS_FEATURE_KEY].eval()),
                        [12, 13, 999])
-      self.assertAlmostEqual(labels["label"].eval(), 0.8)
-      self.assertAlmostEqual(labels["fake_label"].eval(), 0.0)
-      self.assertAlmostEqual(features["label_weight"].eval(), 1.0)
-      self.assertAlmostEqual(features["fake_label_weight"].eval(), 0.0)
+      self.assertAlmostEqual(labels['label'].eval(), 0.8)
+      self.assertAlmostEqual(labels['fake_label'].eval(), 0.0)
+      self.assertAlmostEqual(features['label_weight'].eval(), 1.0)
+      self.assertAlmostEqual(features['fake_label_weight'].eval(), 0.0)
 
   def test_TFRecordInputWithTokenizer_rounded(self):
-    FLAGS.labels = "label"
+    FLAGS.labels = 'label'
     FLAGS.round_labels = True
     dataset_input = tfrecord_input.TFRecordInputWithTokenizer(
         train_preprocess_fn=self.preprocessor)
@@ -163,8 +165,8 @@ class TFRecordInputWithTokenizerTest(tf.test.TestCase):
       features, labels = dataset_input._read_tf_example(self.ex_tensor)
       self.assertEqual(list(features[base_model.TOKENS_FEATURE_KEY].eval()),
                        [12, 13, 999])
-      self.assertEqual(labels["label"].eval(), 1.0)
-      self.assertEqual(features["label_weight"].eval(), 1.0)
+      self.assertEqual(labels['label'].eval(), 1.0)
+      self.assertEqual(features['label_weight'].eval(), 1.0)
 
-if __name__ == "__main__":
+if __name__ == '__main__':
   tf.test.main()

--- a/experiments/tf_trainer/common/tfrecord_input_test.py
+++ b/experiments/tf_trainer/common/tfrecord_input_test.py
@@ -42,6 +42,9 @@ class TFRecordInputTest(tf.test.TestCase):
               'ignored-label':
                   tf.train.Feature(
                       float_list=tf.train.FloatList(value=[0.125])),
+              'int_label':
+                  tf.train.Feature(
+                      int64_list=tf.train.Int64List(value=[0])),
               'comment':
                   tf.train.Feature(
                       bytes_list=tf.train.BytesList(
@@ -65,7 +68,7 @@ class TFRecordInputTest(tf.test.TestCase):
       self.assertCountEqual(list(features), ['text', 'label_weight'])
 
   def test_TFRecordInput_default_values(self):
-    FLAGS.labels = 'label,fake_label'
+    FLAGS.labels = 'label,fake_label,int_label'
     FLAGS.round_labels = False
     dataset_input = tfrecord_input.TFRecordInput()
 
@@ -74,6 +77,7 @@ class TFRecordInputTest(tf.test.TestCase):
       self.assertEqual(features[base_model.TEXT_FEATURE_KEY].eval(),
                        b'Hi there Bob')
       np.testing.assert_almost_equal(labels['label'].eval(), 0.8)
+      np.testing.assert_almost_equal(labels['int_label'].eval(), 0.0)
       np.testing.assert_almost_equal(features['label_weight'].eval(), 1.0)
       np.testing.assert_almost_equal(labels['fake_label'].eval(), 0.0)
       np.testing.assert_almost_equal(features['fake_label_weight'].eval(), 0.0)
@@ -101,6 +105,9 @@ class TFRecordInputWithTokenizerTest(tf.test.TestCase):
               "label":
                   tf.train.Feature(
                       float_list=tf.train.FloatList(value=[0.8])),
+              "int_label":
+                  tf.train.Feature(
+                      int64_list=tf.train.Int64List(value=[0])),
               "comment":
                   tf.train.Feature(
                       bytes_list=tf.train.BytesList(
@@ -118,7 +125,7 @@ class TFRecordInputWithTokenizerTest(tf.test.TestCase):
         [text], tf.int64)
 
   def test_TFRecordInputWithTokenizer_unrounded(self):
-    FLAGS.labels = "label"
+    FLAGS.labels = "label,int_label"
     FLAGS.round_labels = False
     dataset_input = tfrecord_input.TFRecordInputWithTokenizer(
         train_preprocess_fn=self.preprocessor)
@@ -128,6 +135,7 @@ class TFRecordInputWithTokenizerTest(tf.test.TestCase):
       self.assertEqual(list(features[base_model.TOKENS_FEATURE_KEY].eval()),
                        [12, 13, 999])
       self.assertAlmostEqual(labels["label"].eval(), 0.8)
+      self.assertAlmostEqual(labels["int_label"].eval(), 0.0)
       self.assertAlmostEqual(features["label_weight"].eval(), 1.0)
 
   def test_TFRecordInputWithTokenizer_default_values(self):

--- a/experiments/tf_trainer/tf_gru_attention/run.local.sh
+++ b/experiments/tf_trainer/tf_gru_attention/run.local.sh
@@ -18,7 +18,7 @@ python -m tf_trainer.tf_gru_attention.run \
   --validate_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord" \
   --embeddings_path="${GCS_RESOURCES}/glove.6B/glove.6B.100d.txt" \
   --model_dir="tf_gru_attention_local_model_dir" \
-  --labels="toxicity,sever_toxicity,obscene,sexual_explicit,identity_attack,insult,threat"
+  --labels="toxicity,severe_toxicity,obscene,sexual_explicit,identity_attack,insult,threat"
 
 
 


### PR DESCRIPTION
This PR allows for labels to have different dtypes via a new flag "label_dtypes". This can be used to specify the dtypes of each label as being either "float" or "int".

It also fixes:
  - typo in a local run script (sever_toxicity -> severe_toxicity)
  - inconsistent quoting in tfrecord_input.py

This branches from msushkov's commit "Adding test for int64 label" and so also includes unmerged changes from that branch.