### PR TITLE
Adding better error messages when using batch prediction

### DIFF
--- a/model_evaluation/utils_export/dataset.py
+++ b/model_evaluation/utils_export/dataset.py
@@ -47,7 +47,7 @@ class Model(object):
                model_names,
                project_name,
                example_key='example_key'):
-    """Initializes a model.
+    """Initializes a model and defines its signature.
 
     Args:
       feature_keys_spec: spec of the tf_records input to the model.
@@ -56,13 +56,15 @@ class Model(object):
         Format should be $MODEL_NAME:$VERSION. If no version given, will take
           default version.
       project_name: name of the gcp project.
-      example_key: name of the example key expected by the model. This example
-        key will be created by the dataset function.
+      example_key: name of the example key expected by the model.
 
     Raises:
       ValueError: If example_key is included in the feature_spec
         of if feature_keys_spec does not match required format,
         or if we have more than CMLE_QUOTA_PREDICTION model_names.
+
+    Note: When used with `Dataset`, the dataframe returned by the input_fn
+      should not contain the `example_key`, as it will be later created by the API.
     """
 
     utils_tfrecords.is_valid_spec(feature_keys_spec)

--- a/model_evaluation/utils_export/utils_cloudml_test.py
+++ b/model_evaluation/utils_export/utils_cloudml_test.py
@@ -1,0 +1,130 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for tf records utilities."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pandas as pd
+import unittest
+
+import utils_cloudml
+
+
+class CallModelPredictionsFromDf(unittest.TestCase):
+  """Tests for `call_model_predictions_from_df`."""
+
+  #TODO(fprost): Implement these.
+
+  def test_correct(self):
+    return
+
+
+class CheckJobOver(unittest.TestCase):
+  """Tests for `check_job_over`."""
+
+  # TODO(fprost): Implement these.
+  def test_correct(self):
+    return
+
+
+class AddModelPredictionsToDf(unittest.TestCase):
+  """Tests for `add_model_predictions_to_df`."""
+
+  def setUp(self):
+    self.COMMENT_KEY = 'comment_key'
+    self._df = pd.DataFrame({
+        self.COMMENT_KEY: [0, 1],
+        'other_field_1': ['I am a man', 'I am a woman'],
+        })
+    self._prediction_file = 'gs://kaggle-model-experiments/files_for_unittest/model1:v1'
+    self._model_col_name = 'model1:v1_preds'
+    self._prediction_name = 'toxicity/logistic'
+    self._example_key = self.COMMENT_KEY
+
+  def test_missing_prediction_file(self):
+    path = 'not_existing_folder/not_existing_file_path'
+
+    with self.assertRaises(Exception) as context:
+      utils_cloudml.add_model_predictions_to_df(
+          self._df,
+          path,
+          self._model_col_name,
+          self._prediction_name,
+          self._example_key)
+      self.assertIn(
+          'Prediction file does not exist.',
+          str(context.exception))
+
+  def test_empty_prediction_file(self):
+    path = 'gs://kaggle-model-experiments/files_for_unittest/for_empty_predictions'
+
+    with self.assertRaises(Exception) as context:
+      utils_cloudml.add_model_predictions_to_df(
+          self._df,
+          path,
+          self._model_col_name,
+          self._prediction_name,
+          self._example_key)
+    self.assertIn(
+        'The prediction file returned by CMLE is empty.',
+        str(context.exception))
+
+  def test_missing_example_key(self):
+    example_key = 'not_found_example_key'
+    with self.assertRaises(Exception) as context:
+      utils_cloudml.add_model_predictions_to_df(
+          self._df,
+          self._prediction_file,
+          self._model_col_name,
+          self._prediction_name,
+          example_key,
+          )
+    self.assertIn(
+        "Predictions do not contain the 'example_key' field.",
+        str(context.exception))
+
+  def test_missing_prediction_key(self):
+    prediction_key = 'not_found_prediction_key'
+    with self.assertRaises(Exception) as context:
+      utils_cloudml.add_model_predictions_to_df(
+          self._df,
+          self._prediction_file,
+          self._model_col_name,
+          prediction_key,
+          self._example_key)
+    self.assertIn(
+        "Predictions do not contain the 'prediction_name' field.",
+        str(context.exception))
+
+  def test_correct(self):
+    output_df = utils_cloudml.add_model_predictions_to_df(
+        self._df,
+        self._prediction_file,
+        self._model_col_name,
+        self._prediction_name,
+        self._example_key)
+    right_output = pd.DataFrame({
+        self.COMMENT_KEY: [0, 1],
+        'other_field_1': ['I am a man', 'I am a woman'],
+        self._model_col_name: [0.38753455877304077, 0.045782867819070816]
+        })
+    pd.testing.assert_frame_equal(
+        output_df.sort_index(axis=1), right_output.sort_index(axis=1))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/model_evaluation/utils_export/utils_tfrecords_test.py
+++ b/model_evaluation/utils_export/utils_tfrecords_test.py
@@ -64,17 +64,17 @@ class TestFeatureKeySpec(unittest.TestCase):
     feature_keys_spec = 'not_a_dict', 
     with self.assertRaises(Exception) as context:
       utils_tfrecords.is_valid_spec(feature_keys_spec)
-      self.assertIn(
-          'Spec should be a dictionary instance.',
-          str(context.exception))
+    self.assertIn(
+        'Spec should be a dictionary instance.',
+        str(context.exception))
 
   def test_not_in_possible(self):
     feature_keys_spec = {'key': 'other_possibility'} 
     with self.assertRaises(Exception) as context:
       utils_tfrecords.is_valid_spec(feature_keys_spec)
-      self.assertIn(
-          'Spec is badly defined. Authorized types are one of',
-          str(context.exception))
+    self.assertIn(
+        'Spec is badly defined. Authorized types are one of',
+        str(context.exception))
 
   def test_valid(self):
     try:


### PR DESCRIPTION
Adding better messages for the problems highlighted [here](https://github.com/conversationai/conversationai-models/issues/217#event-2029346108).

It will show better message in the case when:
- User gives a bad input signature (feature_keys_spec of `Model`). It leads to an empty prediction file.
- User gives a bad output signature (prediction_keys of `Model`). It leads to being unable to parse the JSON back.

I also added some tests for this part of the code.