### PR TITLE
Refactoring run scripts and moving paths to new project

### DIFF
--- a/experiments/tf_trainer/common/dataset_config.sh
+++ b/experiments/tf_trainer/common/dataset_config.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+BASE_PATH="gs://conversationai-models"
+GCS_RESOURCES="${BASE_PATH}/resources"
+MODEL_PARENT_DIR="${BASE_PATH}/tf_trainer_runs"
+
+if [ "$1" == "civil_comments" ]; then
+    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
+    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
+    labels="toxicity"
+    label_dtypes="float"
+    train_steps=24000
+    eval_period=800
+    eval_steps=50
+
+elif [ "$1" == "toxicity" ]; then
+    train_path="${GCS_RESOURCES}/toxicity_data/toxicity_q42017_train.tfrecord"
+    valid_path="${GCS_RESOURCES}/toxicity_data/toxicity_q42017_validate.tfrecord"
+    labels="frac_neg"
+    label_dtypes="float"
+    train_steps=24000
+    eval_period=800
+    eval_steps=50
+
+elif [ "$1" == "many_communities" ]; then
+    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
+    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
+    labels="removed"
+    label_dtypes="int"
+    train_steps=100000
+    eval_period=800
+    eval_steps=50
+
+else
+    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
+    exit 1
+fi

--- a/experiments/tf_trainer/common/dataset_config.sh
+++ b/experiments/tf_trainer/common/dataset_config.sh
@@ -26,6 +26,8 @@ elif [ "$1" == "many_communities" ]; then
     train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
     valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
     labels="removed"
+    # removed is a boolean variable cast as an int.
+    # 1 means that the comment was removed and 0 means it was not.
     label_dtypes="int"
     train_steps=100000
     eval_period=800

--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -27,7 +27,7 @@ tf.app.flags.DEFINE_string('text_feature', 'comment_text',
                            'Name of feature containing text input.')
 tf.app.flags.DEFINE_boolean('round_labels', True,
                             'Round label features to 0 or 1 if true.')
-tf.app.flags.DEFINE_integer('batch_size', 256,
+tf.app.flags.DEFINE_integer('batch_size', 32,
                             'Batch sizes to use when reading.')
 tf.app.flags.DEFINE_integer('num_prefetch', 5,
                             'Batch sizes to use when reading.')

--- a/experiments/tf_trainer/common/tfrecord_input.py
+++ b/experiments/tf_trainer/common/tfrecord_input.py
@@ -27,7 +27,7 @@ tf.app.flags.DEFINE_string('text_feature', 'comment_text',
                            'Name of feature containing text input.')
 tf.app.flags.DEFINE_boolean('round_labels', True,
                             'Round label features to 0 or 1 if true.')
-tf.app.flags.DEFINE_integer('batch_size', 32,
+tf.app.flags.DEFINE_integer('batch_size', 256,
                             'Batch sizes to use when reading.')
 tf.app.flags.DEFINE_integer('num_prefetch', 5,
                             'Batch sizes to use when reading.')

--- a/experiments/tf_trainer/keras_cnn/run.ml_engine.sh
+++ b/experiments/tf_trainer/keras_cnn/run.ml_engine.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 GCS_RESOURCES="gs://kaggle-model-experiments/resources"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="keras_cnn"
 JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/${DATETIME}
 

--- a/experiments/tf_trainer/keras_gru_attention/run.hyperparameter.sh
+++ b/experiments/tf_trainer/keras_gru_attention/run.hyperparameter.sh
@@ -12,7 +12,7 @@
 # - For glove.6B, Run preprocess_in_tf=False (will force lowercasing).
 
 GCS_RESOURCES="gs://kaggle-model-experiments/resources"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="keras_gru_attention"
 JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/${DATETIME}
 

--- a/experiments/tf_trainer/keras_gru_attention/run.ml_engine.sh
+++ b/experiments/tf_trainer/keras_gru_attention/run.ml_engine.sh
@@ -12,7 +12,7 @@
 # - For glove.6B, Run preprocess_in_tf=Falses (will force lowercasing).
 
 GCS_RESOURCES="gs://kaggle-model-experiments/resources"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="keras_gru_attention"
 JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/${DATETIME}
 

--- a/experiments/tf_trainer/tf_char_cnn/run.deploy.sh
+++ b/experiments/tf_trainer/tf_char_cnn/run.deploy.sh
@@ -3,7 +3,7 @@
 
 if [ "$1" == "civil_comments" ] || [ "$1" == "toxicity" ] || [ "$1" == "many_communities" ] ; then
     
-    MODEL_NAME=tf_char_cnn_$_
+    MODEL_NAME=tf_char_cnn_$1
 
 else
     echo "First positional arg must be one of civil_comments, toxicity, many_communities."
@@ -12,7 +12,7 @@ fi
 
 
 # By default, the model is the last one from the user.
-MODEL_SAVED_PATH=$(gsutil ls gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/ | tail -1)
+MODEL_SAVED_PATH=$(gsutil ls gs://conversationai-models/tf_trainer_runs/${USER}/${MODEL_NAME}/ | tail -1)
 
 # Create a new model.
 # Will raise an error if the model already exists.

--- a/experiments/tf_trainer/tf_char_cnn/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_char_cnn/run.hyperparameter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source "tf_trainer/common/dataset_config.sh"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="tf_char_cnn"
 MODEL_NAME_DATA=${MODEL_NAME}_$1
 JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"

--- a/experiments/tf_trainer/tf_char_cnn/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_char_cnn/run.hyperparameter.sh
@@ -1,48 +1,10 @@
 #!/bin/bash
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
+source "tf_trainer/common/dataset_config.sh"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_char_cnn"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    train_steps=100000
-    eval_period=800
-    eval_steps=50
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
-
 MODEL_NAME_DATA=${MODEL_NAME}_$1
-JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME_DATA}/${DATETIME}
-
+JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"
 
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME_DATA}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \

--- a/experiments/tf_trainer/tf_char_cnn/run.local.sh
+++ b/experiments/tf_trainer/tf_char_cnn/run.local.sh
@@ -1,33 +1,6 @@
 #!/bin/bash
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
+source "tf_trainer/common/dataset_config.sh"
 
 python -m tf_trainer.tf_char_cnn.run \
   --train_path=$train_path \

--- a/experiments/tf_trainer/tf_char_cnn/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_char_cnn/run.ml_engine.sh
@@ -1,47 +1,10 @@
 #!/bin/bash
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
+source "tf_trainer/common/dataset_config.sh"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_char_cnn"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    train_steps=100000
-    eval_period=800
-    eval_steps=50
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
-
-MODEL_NAME_DATA=${MODEL_NAME}_$1
-JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME_DATA}/${DATETIME}
+MODEL_NAME_DATA=${MODEL_NAME}_$1_glove
+JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"
 
 
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME_DATA}_${USER}_${DATETIME} \

--- a/experiments/tf_trainer/tf_char_cnn/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_char_cnn/run.ml_engine.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source "tf_trainer/common/dataset_config.sh"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="tf_char_cnn"
 MODEL_NAME_DATA=${MODEL_NAME}_$1_glove
 JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"

--- a/experiments/tf_trainer/tf_cnn/run.deploy.sh
+++ b/experiments/tf_trainer/tf_cnn/run.deploy.sh
@@ -12,7 +12,7 @@ fi
 
 
 # By default, the model is the last one from the user.
-MODEL_SAVED_PATH=$(gsutil ls gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/ | tail -1)
+MODEL_SAVED_PATH=$(gsutil ls gs://conversationai-models/tf_trainer_runs/${USER}/${MODEL_NAME}/ | tail -1)
 
 # Create a new model.
 # Will raise an error if the model already exists.

--- a/experiments/tf_trainer/tf_cnn/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_cnn/run.hyperparameter.sh
@@ -1,48 +1,10 @@
 #!/bin/bash
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
+source "tf_trainer/common/dataset_config.sh"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_cnn"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    train_steps=100000
-    eval_period=800
-    eval_steps=50
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
-
 MODEL_NAME_DATA=${MODEL_NAME}_$1_glove
-JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME_DATA}/${DATETIME}
-
+JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"
 
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME_DATA}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \

--- a/experiments/tf_trainer/tf_cnn/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_cnn/run.hyperparameter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source "tf_trainer/common/dataset_config.sh"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="tf_cnn"
 MODEL_NAME_DATA=${MODEL_NAME}_$1_glove
 JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"

--- a/experiments/tf_trainer/tf_cnn/run.local.sh
+++ b/experiments/tf_trainer/tf_cnn/run.local.sh
@@ -1,33 +1,6 @@
 #!/bin/bash
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
+source "tf_trainer/common/dataset_config.sh"
 
 python -m tf_trainer.tf_cnn.run \
   --train_path=$train_path \

--- a/experiments/tf_trainer/tf_cnn/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_cnn/run.ml_engine.sh
@@ -1,48 +1,10 @@
 #!/bin/bash
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
+source "tf_trainer/common/dataset_config.sh"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_cnn"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    train_steps=100000
-    eval_period=800
-    eval_steps=50
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
-
 MODEL_NAME_DATA=${MODEL_NAME}_$1_glove
-JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME_DATA}/${DATETIME}
-
+JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"
 
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME_DATA}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \

--- a/experiments/tf_trainer/tf_cnn/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_cnn/run.ml_engine.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source "tf_trainer/common/dataset_config.sh"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="tf_cnn"
 MODEL_NAME_DATA=${MODEL_NAME}_$1_glove
 JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"

--- a/experiments/tf_trainer/tf_gru_attention/run.deploy.sh
+++ b/experiments/tf_trainer/tf_gru_attention/run.deploy.sh
@@ -12,7 +12,7 @@ fi
 
 
 # By default, the model is the last one from the user.
-MODEL_SAVED_PATH=$(gsutil ls gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/ | tail -1)
+MODEL_SAVED_PATH=$(gsutil ls gs://conversationai-models/tf_trainer_runs/${USER}/${MODEL_NAME}/ | tail -1)
 
 # Create a new model.
 # Will raise an error if the model already exists.

--- a/experiments/tf_trainer/tf_gru_attention/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_gru_attention/run.hyperparameter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source "tf_trainer/common/dataset_config.sh"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="tf_gru_attention"
 MODEL_NAME_DATA="${MODEL_NAME}_$1_glove"
 JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"

--- a/experiments/tf_trainer/tf_gru_attention/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_gru_attention/run.hyperparameter.sh
@@ -1,48 +1,10 @@
 #!/bin/bash
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
+source "tf_trainer/common/dataset_config.sh"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_gru_attention"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    train_steps=100000
-    eval_period=800
-    eval_steps=50
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
-
-MODEL_NAME_DATA=${MODEL_NAME}_$1_glove
-JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME_DATA}/${DATETIME}
-
+MODEL_NAME_DATA="${MODEL_NAME}_$1_glove"
+JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"
 
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME_DATA}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \

--- a/experiments/tf_trainer/tf_gru_attention/run.local.sh
+++ b/experiments/tf_trainer/tf_gru_attention/run.local.sh
@@ -10,35 +10,7 @@
 # - For google news: Run preprocess_in_tf=True (no lowercasing).
 # - For glove.6B, Run preprocess_in_tf=False (will force lowercasing).
 
-
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
+source "tf_trainer/common/dataset_config.sh"
 
 python -m tf_trainer.tf_gru_attention.run \
   --train_path=$train_path \
@@ -48,6 +20,3 @@ python -m tf_trainer.tf_gru_attention.run \
   --labels=$labels \
   --label_dtypes=$label_dtypes \
   --preprocess_in_tf=False
-
-
-

--- a/experiments/tf_trainer/tf_gru_attention/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_gru_attention/run.ml_engine.sh
@@ -11,41 +11,11 @@
 # - For google news: Run preprocess_in_tf=True (no lowercasing).
 # - For glove.6B, Run preprocess_in_tf=False (will force lowercasing).
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
+source "tf_trainer/common/dataset_config.sh"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_gru_attention"
-
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
-
 MODEL_NAME_DATA=${MODEL_NAME}_$1_glove
-JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME_DATA}/${DATETIME}
-
+JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"
 
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME_DATA}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \

--- a/experiments/tf_trainer/tf_gru_attention/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_gru_attention/run.ml_engine.sh
@@ -12,7 +12,7 @@
 # - For glove.6B, Run preprocess_in_tf=False (will force lowercasing).
 
 source "tf_trainer/common/dataset_config.sh"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="tf_gru_attention"
 MODEL_NAME_DATA=${MODEL_NAME}_$1_glove
 JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"

--- a/experiments/tf_trainer/tf_hub_classifier/run.deploy.sh
+++ b/experiments/tf_trainer/tf_hub_classifier/run.deploy.sh
@@ -12,7 +12,7 @@ fi
 
 
 # By default, the model is the last one from the user.
-MODEL_SAVED_PATH=$(gsutil ls gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/ | tail -1)
+MODEL_SAVED_PATH=$(gsutil ls gs://conversationai-models/tf_trainer_runs/${USER}/${MODEL_NAME}/ | tail -1)
 
 # Create a new model.
 # Will raise an error if the model already exists.

--- a/experiments/tf_trainer/tf_hub_classifier/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_hub_classifier/run.hyperparameter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source "tf_trainer/common/dataset_config.sh"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="tf_hub_classifier"
 MODEL_NAME_DATA="${MODEL_NAME}_$1"
 JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"

--- a/experiments/tf_trainer/tf_hub_classifier/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_hub_classifier/run.hyperparameter.sh
@@ -1,48 +1,10 @@
 #!/bin/bash
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
+source "tf_trainer/common/dataset_config.sh"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_hub_classifier"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    train_steps=100000
-    eval_period=800
-    eval_steps=50
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
-
-MODEL_NAME_DATA=${MODEL_NAME}_$1
-JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME_DATA}/${DATETIME}
-
+MODEL_NAME_DATA="${MODEL_NAME}_$1"
+JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"
 
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME_DATA}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \

--- a/experiments/tf_trainer/tf_hub_classifier/run.local.sh
+++ b/experiments/tf_trainer/tf_hub_classifier/run.local.sh
@@ -1,33 +1,6 @@
 #!/bin/bash
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
+source "tf_trainer/common/dataset_config.sh"
 
 python -m tf_trainer.tf_hub_classifier.run \
   --train_path=$train_path \

--- a/experiments/tf_trainer/tf_hub_classifier/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_hub_classifier/run.ml_engine.sh
@@ -1,49 +1,11 @@
 #!/bin/bash
 # This script runs one training job on Cloud MLE.
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
+source "tf_trainer/common/dataset_config.sh"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_hub_classifier"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    train_steps=100000
-    eval_period=800
-    eval_steps=50
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    exit 1
-fi
-
-
-MODEL_NAME_DATA=${MODEL_NAME}_$1
-JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME_DATA}/${DATETIME}
-
+MODEL_NAME_DATA="${MODEL_NAME}_$1"
+JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"
 
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME_DATA}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \

--- a/experiments/tf_trainer/tf_hub_classifier/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_hub_classifier/run.ml_engine.sh
@@ -2,7 +2,7 @@
 # This script runs one training job on Cloud MLE.
 
 source "tf_trainer/common/dataset_config.sh"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="tf_hub_classifier"
 MODEL_NAME_DATA="${MODEL_NAME}_$1"
 JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"

--- a/experiments/tf_trainer/tf_word_label_embedding/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_word_label_embedding/run.hyperparameter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source "tf_trainer/common/dataset_config.sh"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="tf_word_label_embedding"
 MODEL_NAME_DATA="${MODEL_NAME}_$1"
 JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"

--- a/experiments/tf_trainer/tf_word_label_embedding/run.hyperparameter.sh
+++ b/experiments/tf_trainer/tf_word_label_embedding/run.hyperparameter.sh
@@ -1,48 +1,10 @@
 #!/bin/bash
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
+source "tf_trainer/common/dataset_config.sh"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_word_label_embedding"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    train_steps=24000
-    eval_period=800
-    eval_steps=50
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    train_steps=100000
-    eval_period=800
-    eval_steps=50
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    return;
-fi
-
-
-MODEL_NAME_DATA=${MODEL_NAME}_$1
-JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME_DATA}/${DATETIME}
-
+MODEL_NAME_DATA="${MODEL_NAME}_$1"
+JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"
 
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME_DATA}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \

--- a/experiments/tf_trainer/tf_word_label_embedding/run.local.sh
+++ b/experiments/tf_trainer/tf_word_label_embedding/run.local.sh
@@ -1,33 +1,6 @@
 #!/bin/bash
 
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
-
-if [ "$1" == "civil_comments" ]; then
-    
-    train_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/train-*.tfrecord"
-    valid_path="${GCS_RESOURCES}/civil_comments_data/train_eval_test/eval-*.tfrecord"
-    labels="toxicity"
-    label_dtypes="float"
-
-elif [ "$1" == "toxicity" ]; then
-
-    train_path="${GCS_RESOURCES}/toxicity_q42017_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/toxicity_q42017_validate.tfrecord"
-    labels="frac_neg"
-    label_dtypes="float"
-
-elif [ "$1" == "many_communities" ]; then
-
-    train_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_train.tfrecord"
-    valid_path="${GCS_RESOURCES}/transfer_learning_data/many_communities/20181105_validate.tfrecord"
-    labels="removed"
-    label_dtypes="int"
-
-else
-    echo "First positional arg must be one of civil_comments, toxicity, many_communities."
-    return;
-fi
-
+source "tf_trainer/common/dataset_config.sh"
 
 python -m tf_trainer.tf_word_label_embedding.run \
   --train_path=$train_path \

--- a/experiments/tf_trainer/tf_word_label_embedding/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_word_label_embedding/run.ml_engine.sh
@@ -11,16 +11,12 @@
 # - For google news: Run preprocess_in_tf=True (no lowercasing).
 # - For glove.6B, Run preprocess_in_tf=False (will force lowercasing).
 
-
-GCS_RESOURCES="gs://kaggle-model-experiments/resources"
+source "tf_trainer/common/dataset_config.sh"
 DATETIME=`date '+%Y%m%d_%H%M%S'`
 MODEL_NAME="tf_word_label_embedding"
-JOB_DIR=gs://kaggle-model-experiments/tf_trainer_runs/${USER}/${MODEL_NAME}/${DATETIME}
-LOCAL_COMET_API_KEY_FILE="comet_api_key.txt"
-REMOTE_COMET_API_KEY_FILE=${GCS_RESOURCES}/${USER}_comet_api_key.txt
+MODEL_NAME_DATA="${MODEL_NAME}_$1"
+JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"
 
-gsutil cp ${LOCAL_COMET_API_KEY_FILE} ${REMOTE_COMET_API_KEY_FILE} &&
-gsutil acl set private ${REMOTE_COMET_API_KEY_FILE} &&
 gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIME} \
     --job-dir=${JOB_DIR} \
     --runtime-version=1.10 \
@@ -36,7 +32,4 @@ gcloud ml-engine jobs submit training tf_trainer_${MODEL_NAME}_${USER}_${DATETIM
     --embeddings_path="${GCS_RESOURCES}/glove.6B/glove.6B.300d.txt" \
     --embedding_size=300 \
     --preprocess_in_tf=False \
-    --model_dir="${JOB_DIR}/model_dir" \
-    --comet_key_file="${REMOTE_COMET_API_KEY_FILE}" \
-    --comet_team_name="jigsaw" \
-    --comet_project_name="experiments"
+    --model_dir="${JOB_DIR}/model_dir" 

--- a/experiments/tf_trainer/tf_word_label_embedding/run.ml_engine.sh
+++ b/experiments/tf_trainer/tf_word_label_embedding/run.ml_engine.sh
@@ -12,7 +12,7 @@
 # - For glove.6B, Run preprocess_in_tf=False (will force lowercasing).
 
 source "tf_trainer/common/dataset_config.sh"
-DATETIME=`date '+%Y%m%d_%H%M%S'`
+DATETIME=$(date '+%Y%m%d_%H%M%S')
 MODEL_NAME="tf_word_label_embedding"
 MODEL_NAME_DATA="${MODEL_NAME}_$1"
 JOB_DIR="${MODEL_PARENT_DIR}/${USER}/${MODEL_NAME_DATA}/${DATETIME}"


### PR DESCRIPTION
This PR refactors the paths for the run scripts and points them to the path for the new cloud project (please refer to the e-mail I sent and respond there if there are any issues or concerns). It also reduces the default batch size of the models so that you don't by default run into OOM error when training on ML engine. 

In a future PR, I will refactor so that we will finally have one run script that can run all of the models instead of having a separate run script per model.